### PR TITLE
Add initial docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker-registry.wikimedia.org/nodejs10-devel
+
+RUN apt-get update && \
+	apt-get install -y \
+		ca-certificates \
+		build-essential \
+		python-pkgconfig \
+		git
+
+ARG UID=1000
+ARG GID=1000
+
+RUN addgroup --gid $GID runuser && adduser --uid $UID --gid $GID --disabled-password --gecos "" runuser
+RUN npm install --global npm@6.14.8
+
+USER runuser

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # query-builder
 🔍️ A simple query builder for Wikidata SPARQL queries
+
+## Development
+
+The following examples use `docker` and `docker-compose` to ease creating a level playing field for development but they are not essential to this project.
+
+### Building the Docker image
+
+```sh
+# ensure the node user uses your user id, so you own created files
+docker-compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) node
+```
+
+### Running npm
+
+```sh
+docker-compose run --rm node npm
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+
+services:
+    node:
+        build:
+            context: ./
+        image: wmde/query-builder
+        volumes:
+            - '~/.npm:/.npm'
+            - './:/app'
+        working_dir: /app


### PR DESCRIPTION
This adds an initial docker-compose.yml for running npm commands. This is copy-pasta of the relevant bits from one of our existing code bases using a similar tech stack, e.g. our design system.

Wikit's docker-compose.yml: https://github.com/wmde/wikit/blob/master/docker-compose.yml

Phabricator: [T263542](https://phabricator.wikimedia.org/T263542)