### PR TITLE
Unify installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,10 @@ The following examples use `docker` and `docker-compose` to ease creating a leve
 ```sh
 # Set up and modify the environment variables according to your preferences
 cp .env.example .env
-```
 
-```sh
 # ensure the node user uses your user id, so you own created files
 docker-compose build --build-arg UID=$(id -u) --build-arg GID=$(id -g) node
-```
 
-```
 # install npm dependencies
 docker-compose run --rm node npm i
 ```


### PR DESCRIPTION
They looked a little inconsistent, with one missing the `sh` in front of the backticks.