### PR TITLE
Fixes to make Toolforge test system to update again

### DIFF
--- a/build/updateCron.yaml
+++ b/build/updateCron.yaml
@@ -27,5 +27,10 @@ spec:
             env:
             - name: HOME
               value: /data/project/query-builder-test
+            resources:
+              - requests:
+                - memory: 1Gi
+              - limits:
+                - memory: 2Gi
           restartPolicy: OnFailure
 

--- a/build/updateCron.yaml
+++ b/build/updateCron.yaml
@@ -28,9 +28,9 @@ spec:
             - name: HOME
               value: /data/project/query-builder-test
             resources:
-              - requests:
-                - memory: 1Gi
-              - limits:
-                - memory: 2Gi
+              requests:
+                memory: 1Gi
+              limits:
+                memory: 2Gi
           restartPolicy: OnFailure
 

--- a/build/updater.sh
+++ b/build/updater.sh
@@ -2,7 +2,7 @@
 cd query-builder
 git pull
 rm -rf node_modules
-npm install npm@6.14.8
+npm install -g npm@6.14.8
 npm install
 npm run build
 rm -rf public_html/*

--- a/build/updater.sh
+++ b/build/updater.sh
@@ -2,7 +2,7 @@
 cd query-builder
 git pull
 rm -rf node_modules
-rm package-lock.json
+npm install npm@6.14.8
 npm install
 npm run build
 rm -rf public_html/*

--- a/build/updater.sh
+++ b/build/updater.sh
@@ -2,6 +2,7 @@
 cd query-builder
 git pull
 rm -rf node_modules
+rm package-lock.json
 npm install
 npm run build
 rm -rf public_html/*


### PR DESCRIPTION
 - Increasing the memory, with the default 0.5Gi, the cron constantly
   OOMs
 - Removing package lock file as it seems that causes error (likely due
   to different npm versions)

With these changes the test system is updating it again.