### PR TITLE
Add *.iml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+*.iml


### PR DESCRIPTION
Currently, IntelliJ creates this file and it shows up in my git status
all the time.