### PR TITLE
Make tokens available for all components

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -18,8 +18,6 @@ export default Vue.extend( {
 </script>
 
 <style scoped lang="scss">
-@import '~@wmde/wikit-tokens/dist/variables';
-
 .querybuilder {
 	padding: 40px;  // $dimension-spacing-xlarge
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+	css: {
+		loaderOptions: {
+			sass: {
+				prependData: '@import "~@wmde/wikit-tokens/dist/variables";'
+			}
+		}
+	}
+};


### PR DESCRIPTION
This loads the tokens via sass-loader which means that we no longer have
to import them for every component that we want to use. It also allows
us to import components from @wmde/wikit-vue-components from the source
files without additional work to load the styles.