### PR TITLE
Introduce QueryObjectBuilder

### DIFF
--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -1,8 +1,9 @@
-import allNamespaces from '@/sparql/RdfNamespaces';
+import rdfNamespaces from '@/sparql/rdfNamespaces';
+import QueryRepresentation from '@/sparql/QueryRepresentation';
+import { SelectQuery } from 'sparqljs';
 
 export default class QueryObjectBuilder {
-	// TODO: Change the type once #27 is merged
-	private queryObject: any;
+	private queryObject: SelectQuery;
 
 	public constructor() {
 		this.queryObject = {
@@ -10,18 +11,19 @@ export default class QueryObjectBuilder {
 			variables: [],
 			where: [],
 			type: 'query',
-			prefixes: allNamespaces
+			prefixes: rdfNamespaces
 		};
 	}
 
-	public buildFromQueryRepresentation( queryRepresentation: any ) {
-		this.queryObject.variables.push(
+	public buildFromQueryRepresentation( queryRepresentation: QueryRepresentation ): SelectQuery {
+
+		this.queryObject.variables = [
 			{
 				termType: 'Variable',
 				value: 'item'
 			}
-		);
-		this.queryObject.where.push(
+		];
+		this.queryObject.where = [
 			{
 				type: 'bgp',
 				triples: [
@@ -32,7 +34,7 @@ export default class QueryObjectBuilder {
 						},
 						predicate: {
 							termType: 'NamedNode',
-							value: 'http://www.wikidata.org/prop/direct/' + queryRepresentation.property
+							value: rdfNamespaces.wdt + queryRepresentation.property.id
 						},
 						object: {
 							termType: 'Literal',
@@ -41,7 +43,7 @@ export default class QueryObjectBuilder {
 					}
 				]
 			}
-		);
+		];
 
 		return this.queryObject;
 	}

--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -1,0 +1,48 @@
+import allNamespaces from '@/sparql/RdfNamespaces';
+
+export default class QueryObjectBuilder {
+	// TODO: Change the type once #27 is merged
+	private queryObject: any;
+
+	public constructor() {
+		this.queryObject = {
+			queryType: 'SELECT',
+			variables: [],
+			where: [],
+			type: 'query',
+			prefixes: allNamespaces
+		};
+	}
+
+	public buildFromQueryRepresentation( queryRepresentation: any ) {
+		this.queryObject.variables.push(
+			{
+				termType: 'Variable',
+				value: 'item'
+			}
+		);
+		this.queryObject.where.push(
+			{
+				type: 'bgp',
+				triples: [
+					{
+						subject: {
+							termType: 'Variable',
+							value: 'item'
+						},
+						predicate: {
+							termType: 'NamedNode',
+							value: 'http://www.wikidata.org/prop/direct/' + queryRepresentation.property
+						},
+						object: {
+							termType: 'Literal',
+							value: queryRepresentation.value
+						}
+					}
+				]
+			}
+		);
+
+		return this.queryObject;
+	}
+}

--- a/src/sparql/buildQuery.ts
+++ b/src/sparql/buildQuery.ts
@@ -1,41 +1,11 @@
 import QueryRepresentation from './QueryRepresentation';
 import QueryBuilderSparqlGenerator from '@/sparql/QueryBuilderSparqlGenerator';
-import rdfNamespaces from '@/sparql/rdfNamespaces';
 import { Generator as SparqlGenerator, SelectQuery } from 'sparqljs';
+import QueryObjectBuilder from '@/sparql/QueryObjectBuilder';
 
 export default function buildQuery( query: QueryRepresentation ): string {
-	const queryObject: SelectQuery = {
-		queryType: 'SELECT',
-		variables: [
-			{
-				termType: 'Variable',
-				value: 'item'
-			}
-		],
-		where: [
-			{
-				type: 'bgp',
-				triples: [
-					{
-						subject: {
-							termType: 'Variable',
-							value: 'item'
-						},
-						predicate: {
-							termType: 'NamedNode',
-							value: rdfNamespaces.wdt + query.property.id
-						},
-						object: {
-							termType: 'Literal',
-							value: query.value
-						}
-					}
-				]
-			}
-		],
-		type: 'query',
-		prefixes: rdfNamespaces
-	};
+	const queryObjectBuilder = new QueryObjectBuilder();
+	const queryObject: SelectQuery = queryObjectBuilder.buildFromQueryRepresentation( query );
 	const queryBuilderSparqlGenerator = new QueryBuilderSparqlGenerator( new SparqlGenerator() );
 
 	return queryBuilderSparqlGenerator.getString( queryObject );

--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -1,0 +1,48 @@
+import allNamespaces from '@/sparql/RdfNamespaces';
+import QueryObjectBuilder from '@/sparql/QueryObjectBuilder';
+
+describe( 'QueryObjectBuilder', () => {
+	it( 'einfach', () => {
+		const prefixes = allNamespaces;
+		const builder = new QueryObjectBuilder();
+		const expected = {
+			queryType: 'SELECT',
+			variables: [
+				{
+					termType: 'Variable',
+					value: 'item'
+				}
+			],
+			where: [
+				{
+					type: 'bgp',
+					triples: [
+						{
+							subject: {
+								termType: 'Variable',
+								value: 'item'
+							},
+							predicate: {
+								termType: 'NamedNode',
+								value: 'http://www.wikidata.org/prop/direct/P281'
+							},
+							object: {
+								termType: 'Literal',
+								value: 'XXXX'
+							}
+						}
+					]
+				}
+			],
+			type: 'query',
+			prefixes: prefixes
+		};
+
+		const actual = builder.buildFromQueryRepresentation( {
+			property: 'P281',
+			value: 'XXXX'
+		} );
+
+		expect( actual ).toStrictEqual( expected );
+	} );
+} );

--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -2,7 +2,7 @@ import allNamespaces from '@/sparql/rdfNamespaces';
 import QueryObjectBuilder from '@/sparql/QueryObjectBuilder';
 
 describe( 'QueryObjectBuilder', () => {
-	it( 'einfach', () => {
+	it( 'simple', () => {
 		const prefixes = allNamespaces;
 		const builder = new QueryObjectBuilder();
 		const expected = {

--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -1,4 +1,4 @@
-import allNamespaces from '@/sparql/RdfNamespaces';
+import allNamespaces from '@/sparql/rdfNamespaces';
 import QueryObjectBuilder from '@/sparql/QueryObjectBuilder';
 
 describe( 'QueryObjectBuilder', () => {
@@ -39,7 +39,10 @@ describe( 'QueryObjectBuilder', () => {
 		};
 
 		const actual = builder.buildFromQueryRepresentation( {
-			property: 'P281',
+			property: {
+				id: 'P281',
+				label: 'Postal Code'
+			},
 			value: 'XXXX'
 		} );
 


### PR DESCRIPTION
Simple builder that takes a QueryRepresentation and produce the object
sparqljs would understand.

Currently, the types are not in master yet and as the result, lints fail
for using a general "any" type.