### PR TITLE
Enable `allow-popups` for the query results iframe

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -37,7 +37,7 @@
 				:key="iframeRenderKey"
 				class="querybuilder__result__iframe"
 				referrerpolicy="origin"
-				sandbox="allow-scripts allow-same-origin">
+				sandbox="allow-scripts allow-same-origin allow-popups">
 			</iframe>
 		</div>
 	</div>


### PR DESCRIPTION
This is needed to let links in the results table open in a new window
when clicked.

Bug: T263568