### PR TITLE
Add SearchEntityRepository interface

### DIFF
--- a/src/data-access/SearchEntityRepository.ts
+++ b/src/data-access/SearchEntityRepository.ts
@@ -1,0 +1,9 @@
+import SearchResult from './SearchResult';
+
+/**
+ * Repository to search for entities.
+ * The language will be defined in the constructor as will be further options
+ */
+export default interface SearchEntityRepository {
+    searchProperties( searchString: string, limit?: number, offset?: number ): Promise<Array<SearchResult>>;
+}

--- a/src/data-access/SearchResult.ts
+++ b/src/data-access/SearchResult.ts
@@ -1,0 +1,5 @@
+export default interface SearchResult {
+	id: string,
+	label: string,
+	description: string,
+}


### PR DESCRIPTION
~~We probably do not want to use pagination in any of the use cases for
this hike as it would require multiple requests and that is probably a
bad experience for a autocomplete.~~
Turns out we are going to need pagination after all.

The actual server response contains a lot more information than just
what is currently defined in SearchResult. But it seems sensible to keep
the interface limited to what we really need just for now.

Bug: T266555