### PR TITLE
Spin off the result part of query builder component to a child component

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -25,21 +25,10 @@
 				<Button @click.native="runQuery" type="primaryProgressive">Run query</Button>
 			</div>
 		</div>
-		<div class="querybuilder__result">
-			<div v-if="encodedQuery.length === 0" class="querybuilder__result__description">
-				Results will be displayed here
-			</div>
-
-			<!-- TODO use global config variables instead of hardcoding the url-->
-			<iframe
-				v-else
-				:src="'https://query.wikidata.org/embed.html#' + encodedQuery"
-				:key="iframeRenderKey"
-				class="querybuilder__result__iframe"
-				referrerpolicy="origin"
-				sandbox="allow-scripts allow-same-origin allow-popups">
-			</iframe>
-		</div>
+		<QueryResult
+				:encodedQuery="encodedQuery"
+				:iframeRenderKey="iframeRenderKey"
+		/>
 	</div>
 </template>
 
@@ -48,6 +37,7 @@ import Vue from 'vue';
 import TextInput from '@wmde/wikit-vue-components/src/components/TextInput.vue';
 import Button from '@wmde/wikit-vue-components/src/components/Button.vue';
 import { mapState } from 'vuex';
+import QueryResult from '@/components/QueryResult.vue';
 import buildQuery from '@/sparql/buildQuery';
 
 export default Vue.extend( {
@@ -77,7 +67,8 @@ export default Vue.extend( {
 	},
 	components: {
 		Button,
-		TextInput
+		TextInput,
+		QueryResult
 	}
 } );
 </script>
@@ -126,25 +117,5 @@ export default Vue.extend( {
 
 .querybuilder__run {
 	margin-block-start: $dimension-layout-medium;
-}
-
-.querybuilder__result {
-	margin-block-start: $dimension-layout-small;
-}
-
-.querybuilder__result__description {
-	padding-block: $dimension-spacing-xxlarge;
-	font-size: $font-size-style-description;
-	font-family: $font-family-style-description;
-	color: $font-color-subtle;
-	font-weight: $font-weight-style-description;
-	line-height: $font-line-height-style-description;
-	text-align: center;
-}
-
-.querybuilder__result__iframe {
-	width: $dimension-width-full;
-	border: none;
-	height: 95vh;
 }
 </style>

--- a/src/components/QueryResult.vue
+++ b/src/components/QueryResult.vue
@@ -1,0 +1,67 @@
+<template>
+	<div class="querybuilder__result">
+		<div v-if="encodedQuery.length === 0" class="querybuilder__result__description">
+			Results will be displayed here
+		</div>
+
+		<!-- TODO use global config variables instead of hardcoding the url-->
+		<iframe
+				v-else
+				:src="'https://query.wikidata.org/embed.html#' + encodedQuery"
+				:key="iframeRenderKey"
+				class="querybuilder__result__iframe"
+				referrerpolicy="origin"
+				sandbox="allow-scripts allow-same-origin allow-popups">
+		</iframe>
+	</div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { mapState } from 'vuex';
+
+export default Vue.extend( {
+	name: 'QueryResult',
+	props: {
+		encodedQuery: {
+			type: String
+		},
+		iframeRenderKey: {
+			type: Number
+		}
+	},
+	methods: {
+		updateInputTextValue( value: string ): void {
+			this.$store.dispatch( 'updateValue', value );
+		}
+	},
+	computed: {
+		...mapState( {
+			property: 'property',
+			textInputValue: 'value'
+		} )
+	}
+} );
+</script>
+
+<style scoped lang="scss">
+	.querybuilder__result {
+		margin-block-start: $dimension-layout-small;
+	}
+
+	.querybuilder__result__description {
+		padding-block: $dimension-spacing-xxlarge;
+		font-size: $font-size-style-description;
+		font-family: $font-family-style-description;
+		color: $font-color-subtle;
+		font-weight: $font-weight-style-description;
+		line-height: $font-line-height-style-description;
+		text-align: center;
+	}
+
+	.querybuilder__result__iframe {
+		width: $dimension-width-full;
+		border: none;
+		height: 95vh;
+	}
+</style>

--- a/src/data-access/SearchEntityRepository.ts
+++ b/src/data-access/SearchEntityRepository.ts
@@ -5,5 +5,5 @@ import SearchResult from './SearchResult';
  * The language will be defined in the constructor as will be further options
  */
 export default interface SearchEntityRepository {
-    searchProperties( searchString: string, limit?: number, offset?: number ): Promise<Array<SearchResult>>;
+	searchProperties( searchString: string, limit?: number, offset?: number ): Promise<SearchResult[]>;
 }

--- a/src/data-access/SearchResult.ts
+++ b/src/data-access/SearchResult.ts
@@ -1,5 +1,5 @@
 export default interface SearchResult {
-	id: string,
-	label: string,
-	description: string,
+	id: string;
+	label: string;
+	description: string;
 }

--- a/tests/unit/QueryResult.spec.ts
+++ b/tests/unit/QueryResult.spec.ts
@@ -1,0 +1,30 @@
+import Vuex, { Store } from 'vuex';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import QueryResult from '@/components/QueryResult.vue';
+
+function newStore( state = {} ): Store<any> {
+	return new Vuex.Store( {
+		state: {
+			property: 'potato',
+			...state
+		}
+	} );
+}
+
+const localVue = createLocalVue();
+localVue.use( Vuex );
+
+describe( 'QueryResult.vue', () => {
+	it( 'Show an empty page without input', () => {
+		const wrapper = shallowMount( QueryResult, {
+			store: newStore(),
+			localVue,
+			propsData: {
+				encodedQuery: '',
+				iframeRenderKey: 0
+			}
+		} );
+		expect( wrapper.find( 'div' ).text() ).toBe( 'Results will be displayed here' );
+		expect( wrapper.findAll( 'iframe' ) ).toHaveLength( 0 );
+	} );
+} );


### PR DESCRIPTION
Having "fat component" is an anti-pattern in Vue and it's highly
recommended to keep logic in *.vue files below some threshold.

This will also help in future when adding the error handling.