### PR TITLE
Use Lookup component

### DIFF
--- a/src/components/PropertyLookup.vue
+++ b/src/components/PropertyLookup.vue
@@ -1,0 +1,50 @@
+<template>
+	<Lookup
+		:value="value"
+		@input="$emit( 'input', $event )"
+		:error="error"
+		:menu-items="searchResults"
+		:search-input.sync="search"
+		placeholder="Enter a property"
+		label="Property"
+	>
+		<template v-slot:no-results>
+			No match was found
+		</template>
+	</Lookup>
+</template>
+
+<script lang="ts">
+import { MenuItem } from '@wmde/wikit-vue-components/dist/components/MenuItem';
+import Vue, { PropType } from 'vue';
+
+import { Lookup } from '@wmde/wikit-vue-components';
+
+export default Vue.extend( {
+	name: 'PropertyLookup',
+	components: {
+		Lookup,
+	},
+	data() {
+		return {
+			search: '',
+			searchResults: [],
+		};
+	},
+	watch: {
+		async search( newSearchString: string ): Promise<void> {
+			this.searchResults = await this.$store.dispatch( 'searchProperties', newSearchString );
+		},
+	},
+	props: {
+		value: {
+			type: Object as PropType<MenuItem>,
+			default: null,
+		},
+		error: {
+			type: Object,
+			default: null,
+		},
+	},
+} );
+</script>

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -9,12 +9,10 @@
 		<div role="form">
 			<h2 class="querybuilder__find-title">Find all items...</h2>
 			<div class="querybuilder__rule">
-				<TextInput
-					class="querybuilder__rule__property"
-					label="Property"
-					:value="selectedItem.label"
+				<PropertyLookup
+					v-model="selectedItem"
 					:error="fieldErrors.property"
-					placeholder="Enter a property" />
+				/>
 				<TextInput
 					class="querybuilder__rule__value"
 					label="Value"
@@ -36,13 +34,15 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { TextInput } from '@wmde/wikit-vue-components';
-import { Button } from '@wmde/wikit-vue-components';
-import QueryResult from '@/components/QueryResult.vue';
-import buildQuery from '@/sparql/buildQuery';
-import Property from '@/data-model/Property';
 import { mapState } from 'vuex';
+import { Button, TextInput } from '@wmde/wikit-vue-components';
+
+import PropertyLookup from '@/components/PropertyLookup.vue';
+import QueryResult from '@/components/QueryResult.vue';
+import SearchResult from '@/data-access/SearchResult';
+import Property from '@/data-model/Property';
 import Error from '@/data-model/Error';
+import buildQuery from '@/sparql/buildQuery';
 
 export default Vue.extend( {
 	name: 'QueryBuilder',
@@ -104,6 +104,9 @@ export default Vue.extend( {
 	computed: {
 		selectedItem: {
 			get(): Property { return this.$store.getters.property; },
+			set( selectedItem: SearchResult ): void {
+				this.$store.dispatch( 'updateProperty', selectedItem );
+			},
 		},
 		textInputValue: {
 			get(): string { return this.$store.getters.value; },
@@ -117,6 +120,7 @@ export default Vue.extend( {
 		Button,
 		TextInput,
 		QueryResult,
+		PropertyLookup,
 	},
 } );
 </script>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,12 +1,17 @@
 import { ActionContext } from 'vuex';
 import RootState from './RootState';
-import Property from '@/data-model/Property';
 import SearchEntityRepository from '@/data-access/SearchEntityRepository';
+import SearchResult from '@/data-access/SearchResult';
 import Error from '@/data-model/Error';
+import Property from '@/data-model/Property';
 
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
-export default ( _searchEntityRepository: SearchEntityRepository ) => ( {
+export default ( searchEntityRepository: SearchEntityRepository ) => ( {
+	async searchProperties( _context: ActionContext<RootState, RootState>, search: string ): Promise<SearchResult[]> {
+		// check for empty
+		return await searchEntityRepository.searchProperties( search, 12 );
+	},
 	updateValue( context: ActionContext<RootState, RootState>, value: string ): void {
 		context.commit( 'setValue', value );
 	},

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,8 +15,8 @@ export function createStore( services: QueryBuilderServices ): Store<RootState> 
 		state: {
 			conditionRow: {
 				propertyData: {
-					label: 'postal code',
-					id: 'P281',
+					label: '',
+					id: '',
 				},
 				valueData: {
 					value: '',

--- a/tests/unit/components/PropertyLookup.spec.ts
+++ b/tests/unit/components/PropertyLookup.spec.ts
@@ -1,0 +1,67 @@
+import PropertyLookup from '@/components/PropertyLookup.vue';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { Lookup } from '@wmde/wikit-vue-components';
+import Vuex from 'vuex';
+
+const localVue = createLocalVue();
+localVue.use( Vuex );
+
+describe( 'PropertyLookup.vue', () => {
+	it( 'bubbles input events from the Lookup up', () => {
+		const wrapper = shallowMount( PropertyLookup );
+		const someEventContent = {};
+
+		wrapper.findComponent( Lookup ).vm.$emit( 'input', someEventContent );
+
+		expect( wrapper.emitted( 'input' )![ 0 ][ 0 ] ).toBe( someEventContent );
+	} );
+
+	it( 'pass value prop down to Lookup', () => {
+		const property = {
+			label: 'some label',
+			description: 'some description',
+		};
+
+		const wrapper = shallowMount( PropertyLookup, {
+			propsData: {
+				value: property,
+			},
+		} );
+
+		expect( wrapper.findComponent( Lookup ).props( 'value' ) ).toBe( property );
+	} );
+
+	it( 'dispatches action to search for Properties on new search string', async () => {
+		const store = new Vuex.Store( {} );
+		const searchRsults = [ { label: 'abc', description: 'def', id: 'P123' } ];
+		store.dispatch = jest.fn().mockResolvedValue( searchRsults );
+		const wrapper = shallowMount( PropertyLookup, { store, localVue } );
+
+		const searchString = 'postal';
+		wrapper.findComponent( Lookup ).vm.$emit( 'update:search-input', searchString );
+		await localVue.nextTick();
+
+		expect( store.dispatch ).toHaveBeenCalledWith( 'searchProperties', searchString );
+		expect( wrapper.findComponent( Lookup ).props( 'searchInput' ) ).toBe( searchString );
+
+		// it really needs two ticks ¯\_(ツ)_/¯
+		await localVue.nextTick();
+		await localVue.nextTick();
+		expect( wrapper.findComponent( Lookup ).props( 'menuItems' ) ).toBe( searchRsults );
+	} );
+
+	it( 'passes error prop down to Lookup', () => {
+		const error = {
+			type: 'error',
+			message: 'some description',
+		};
+
+		const wrapper = shallowMount( PropertyLookup, {
+			propsData: {
+				error,
+			},
+		} );
+
+		expect( wrapper.findComponent( Lookup ).props( 'error' ) ).toBe( error );
+	} );
+} );

--- a/tests/unit/components/QueryBuilder.spec.ts
+++ b/tests/unit/components/QueryBuilder.spec.ts
@@ -1,7 +1,8 @@
+import { TextInput } from '@wmde/wikit-vue-components';
 import Vuex, { Store } from 'vuex';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import QueryBuilder from '@/components/QueryBuilder.vue';
-import { TextInput } from '@wmde/wikit-vue-components';
+import PropertyLookup from '@/components/PropertyLookup.vue';
 
 function newStore( getters = {} ): Store<any> {
 	return new Vuex.Store( {
@@ -24,18 +25,30 @@ describe( 'QueryBuilder.vue', () => {
 		expect( wrapper.find( 'h1' ).text() ).toBe( 'Simple Query Builder' );
 	} );
 
-	it( 'renders the Property label in the property textfield', () => {
-		const propertyLabel = 'postal code';
+	it( 'passes the selected property back to the PropertyLookup', async () => {
+		const property = { label: 'postal code', id: 'P123' };
 		const wrapper = shallowMount( QueryBuilder, {
 			store: newStore( {
-				property: jest.fn().mockReturnValue( {
-					label: propertyLabel,
-				} ),
+				property: jest.fn().mockReturnValue( property ),
 			} ),
 			localVue,
 		} );
 
-		expect( wrapper.findComponent( TextInput ).props( 'value' ) ).toBe( propertyLabel );
+		expect( wrapper.findComponent( PropertyLookup ).props( 'value' ) ).toBe( property );
+	} );
+
+	it( 'updates the store property when the user changes it in the lookup', async () => {
+		const property = { label: 'postal code', id: 'P123' };
+		const store = newStore();
+		store.dispatch = jest.fn();
+		const wrapper = shallowMount( QueryBuilder, {
+			store,
+			localVue,
+		} );
+
+		wrapper.findComponent( PropertyLookup ).vm.$emit( 'input', property );
+
+		expect( store.dispatch ).toHaveBeenCalledWith( 'updateProperty', property );
 	} );
 
 	it( 'updates the store value when the user fills in the value textfield', () => {
@@ -75,11 +88,11 @@ describe( 'QueryBuilder.vue', () => {
 			},
 		} );
 
-		expect( wrapper.findAllComponents( TextInput ).at( 0 ).props( 'error' ) ).toStrictEqual( {
+		expect( wrapper.findComponent( PropertyLookup ).props( 'error' ) ).toStrictEqual( {
 			type: 'error',
 			message: 'Property Error Message!',
 		} );
-		expect( wrapper.findAllComponents( TextInput ).at( 1 ).props( 'error' ) ).toStrictEqual( {
+		expect( wrapper.findComponent( TextInput ).props( 'error' ) ).toStrictEqual( {
 			type: 'warning',
 			message: 'Value Warning Message!',
 		} );

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -29,4 +29,20 @@ describe( 'actions', () => {
 		expect( context.commit ).toHaveBeenCalledWith( 'setProperty', property );
 	} );
 
+	describe( 'searchProperties', () => {
+		it( 'calls the repo and resolves with the result', async () => {
+			const expectedResult = [ { label: 'postal code', id: 'P123' } ];
+			const searchProperties = jest.fn().mockResolvedValue( expectedResult );
+			const actions = createActions(
+				{ searchProperties },
+			);
+			const searchString = 'postal';
+
+			const actualResult = await actions.searchProperties( {} as any, searchString );
+
+			expect( searchProperties ).toHaveBeenCalledWith( searchString, 12 );
+			expect( actualResult ).toBe( expectedResult );
+		} );
+	} );
+
 } );


### PR DESCRIPTION
Working, but still a lot to do

Todo:
- **tests**
  - [x] tests for QueryBuilder
  - [x] tests for PropertyLookup
  - [x] tests for the new action
- ~~[ ] Add debounce to request for property search results~~ Will be done in extra PR/Story
- [x] double check that all the types make sense, esp. MenuItem and SearchResult
- [x] split the change to the mutation test into an extra commit (maybe other PR)
- [x] squash the other PropertyLookup commit into the preceding one