### PR TITLE
Restructure state to make it more extendable

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -12,14 +12,13 @@
 				<TextInput
 					class="querybuilder__rule__property"
 					label="Property"
-					:value="property.label"
+					:value="selectedItem.label"
 					placeholder="Enter a property" />
 				<TextInput
 					class="querybuilder__rule__value"
 					label="Value"
 					ref="value"
-					:value="textInputValue"
-					@input="updateInputTextValue"
+					v-model="textInputValue"
 					placeholder="Enter a value" />
 			</div>
 			<div class="querybuilder__run">
@@ -37,9 +36,9 @@
 import Vue from 'vue';
 import TextInput from '@wmde/wikit-vue-components/src/components/TextInput.vue';
 import Button from '@wmde/wikit-vue-components/src/components/Button.vue';
-import { mapState } from 'vuex';
 import QueryResult from '@/components/QueryResult.vue';
 import buildQuery from '@/sparql/buildQuery';
+import Property from '@/data-model/Property';
 
 export default Vue.extend( {
 	name: 'QueryBuilder',
@@ -50,9 +49,6 @@ export default Vue.extend( {
 		};
 	},
 	methods: {
-		updateInputTextValue( value: string ): void {
-			this.$store.dispatch( 'updateValue', value );
-		},
 		runQuery(): void {
 			this.encodedQuery = encodeURI( buildQuery( this.$store.getters.query ) );
 
@@ -61,10 +57,13 @@ export default Vue.extend( {
 		},
 	},
 	computed: {
-		...mapState( {
-			property: 'property',
-			textInputValue: 'value',
-		} ),
+		selectedItem: {
+			get(): Property { return this.$store.getters.property; },
+		},
+		textInputValue: {
+			get(): string { return this.$store.getters.value; },
+			set( value: string ): void { this.$store.dispatch( 'updateValue', value ); },
+		},
 	},
 	components: {
 		Button,

--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -34,11 +34,11 @@ export default class QueryObjectBuilder {
 						},
 						predicate: {
 							termType: 'NamedNode',
-							value: rdfNamespaces.wdt + queryRepresentation.property.id,
+							value: rdfNamespaces.wdt + queryRepresentation.condition.propertyId,
 						},
 						object: {
 							termType: 'Literal',
-							value: queryRepresentation.value,
+							value: queryRepresentation.condition.value,
 						},
 					},
 				],

--- a/src/sparql/QueryRepresentation.ts
+++ b/src/sparql/QueryRepresentation.ts
@@ -1,6 +1,8 @@
-import Property from '@/data-model/Property';
+export type Condition = {
+	propertyId: string;
+	value: string;
+};
 
 export default interface QueryRepresentation {
-	property: Property;
-	value: string;
+	condition: Condition;
 }

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -1,4 +1,13 @@
-import QueryRepresentation from '@/sparql/QueryRepresentation';
+export default interface RootState {
+	conditionRow: ConditionRow;
+}
 
-export interface RootState extends QueryRepresentation {
+export interface ConditionRow {
+	propertyData: {
+		id: string;
+		label: string;
+	};
+	valueData: {
+		value: string;
+	};
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,5 +1,5 @@
 import { ActionContext } from 'vuex';
-import { RootState } from './RootState';
+import RootState from './RootState';
 import Property from '@/data-model/Property';
 import SearchEntityRepository from '@/data-access/SearchEntityRepository';
 

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -1,12 +1,20 @@
-import { RootState } from './RootState';
+import RootState from './RootState';
 import QueryRepresentation from '@/sparql/QueryRepresentation';
 import Property from '@/data-model/Property';
 
 export default {
-	query( { property, value }: RootState ): QueryRepresentation {
-		return { property, value };
+	query( rootState: RootState ): QueryRepresentation {
+		return {
+			condition: {
+				propertyId: rootState.conditionRow.propertyData.id,
+				value: rootState.conditionRow.valueData.value,
+			},
+		};
 	},
-	getProperty( rootState: RootState ): Property {
-		return rootState.property;
+	property( rootState: RootState ): Property {
+		return rootState.conditionRow.propertyData;
+	},
+	value( rootState: RootState ): string {
+		return rootState.conditionRow.valueData.value;
 	},
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,7 +5,7 @@ import createActions from './actions';
 import mutations from './mutations';
 import getters from './getters';
 import QueryBuilderServices from '@/QueryBuilderServices';
-import { RootState } from '@/store/RootState';
+import RootState from '@/store/RootState';
 
 Vue.use( Vuex );
 
@@ -13,11 +13,15 @@ export function createStore( services: QueryBuilderServices ): Store<RootState> 
 
 	return new Store( {
 		state: {
-			property: {
-				label: 'postal code',
-				id: 'P281',
+			conditionRow: {
+				propertyData: {
+					label: 'postal code',
+					id: 'P281',
+				},
+				valueData: {
+					value: '',
+				},
 			},
-			value: '',
 		},
 		actions: createActions(
 			services.get( 'searchEntityRepository' ),

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -1,11 +1,11 @@
-import { RootState } from './RootState';
+import RootState from './RootState';
 import Property from '@/data-model/Property';
 
 export default {
 	setValue( state: RootState, value: string ): void {
-		state.value = value;
+		state.conditionRow.valueData.value = value;
 	},
 	setProperty( state: RootState, property: Property ): void {
-		state.property = property;
+		state.conditionRow.propertyData = property;
 	},
 };

--- a/tests/unit/QueryBuilder.spec.ts
+++ b/tests/unit/QueryBuilder.spec.ts
@@ -3,11 +3,13 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import TextInput from '@wmde/wikit-vue-components/src/components/TextInput.vue';
 
-function newStore( state = {} ): Store<any> {
+function newStore( getters = {} ): Store<any> {
 	return new Vuex.Store( {
-		state: {
-			property: 'potato',
-			...state,
+		getters: {
+			property: jest.fn().mockReturnValue( {
+				label: 'potato',
+			} ),
+			...getters,
 		},
 	} );
 }
@@ -25,7 +27,11 @@ describe( 'QueryBuilder.vue', () => {
 	it( 'renders the Property label in the property textfield', () => {
 		const propertyLabel = 'postal code';
 		const wrapper = shallowMount( QueryBuilder, {
-			store: newStore( { property: { label: propertyLabel } } ),
+			store: newStore( {
+				property: jest.fn().mockReturnValue( {
+					label: propertyLabel,
+				} ),
+			} ),
 			localVue,
 		} );
 

--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -39,11 +39,10 @@ describe( 'QueryObjectBuilder', () => {
 		};
 
 		const actual = builder.buildFromQueryRepresentation( {
-			property: {
-				id: 'P281',
-				label: 'Postal Code',
+			condition: {
+				propertyId: 'P281',
+				value: 'XXXX',
 			},
-			value: 'XXXX',
 		} );
 
 		expect( actual ).toStrictEqual( expected );

--- a/tests/unit/sparql/buildQuery.spec.ts
+++ b/tests/unit/sparql/buildQuery.spec.ts
@@ -3,12 +3,12 @@ import buildQuery from '@/sparql/buildQuery';
 describe( 'buildQuery', () => {
 
 	it( 'builds a query from a property and a string value', () => {
-		const property = { label: 'potato', id: 'P666' };
+		const propertyId = 'P666';
 		const value = 'blah';
-		expect( buildQuery( {
-			property,
+		expect( buildQuery( { condition: {
+			propertyId,
 			value,
-		} ) ).toEqual( `SELECT ?item WHERE { ?item wdt:${property.id} "${value}". }` );
+		} } ) ).toEqual( `SELECT ?item WHERE { ?item wdt:${propertyId} "${value}". }` );
 	} );
 
 } );

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -1,24 +1,34 @@
 import mutations from '@/store/mutations';
-import { RootState } from '@/store/RootState';
+import RootState from '@/store/RootState';
 
 describe( 'mutations', () => {
 
 	it( 'setValue', () => {
 		const expectedValue = 'whatever';
-		const state: RootState = { value: 'foo', property: { id: 'P123', label: 'abc' } };
+		const state: RootState = {
+			conditionRow: {
+				valueData: { value: 'foo' },
+				propertyData: { id: 'P123', label: 'abc' },
+			},
+		};
 
 		mutations.setValue( state, expectedValue );
 
-		expect( state.value ).toBe( expectedValue );
+		expect( state.conditionRow.valueData.value ).toBe( expectedValue );
 	} );
 
 	it( 'setProperty', () => {
 		const expectedProperty = { id: 'P123', label: 'abc' };
-		const state: RootState = { value: 'foo', property: { id: 'P123', label: 'abc' } };
+		const state: RootState = {
+			conditionRow: {
+				valueData: { value: 'foo' },
+				propertyData: { id: 'P123', label: 'abc' },
+			},
+		};
 
 		mutations.setProperty( state, expectedProperty );
 
-		expect( state.property ).toBe( expectedProperty );
+		expect( state.conditionRow.propertyData ).toBe( expectedProperty );
 	} );
 
 } );


### PR DESCRIPTION
"condition" is the domain name for one clause or group in the query builder. The state for a condition will in the future both contain the data needed for the query itself and some metadata like the search results or the errors.