### PR TITLE
Add test for the nontrivial query getter

### DIFF
--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -1,0 +1,25 @@
+import RootState from '@/store/RootState';
+import getters from '@/store/getters';
+import QueryRepresentation from '@/sparql/QueryRepresentation';
+
+describe( 'getters', () => {
+	describe( 'query', () => {
+		it( 'returns the QueryRepresentation of the RootState', () => {
+			const state: RootState = {
+				conditionRow: {
+					valueData: { value: 'foo' },
+					propertyData: { id: 'P123', label: 'abc' },
+				},
+			};
+
+			const expectedValue: QueryRepresentation = {
+				condition: {
+					propertyId: 'P123',
+					value: 'foo',
+				},
+			};
+
+			expect( getters.query( state ) ).toStrictEqual( expectedValue );
+		} );
+	} );
+} );


### PR DESCRIPTION
This getter will become very important and complex as it is the one that will transform the RootState into a QueryRepresentation.