### PR TITLE
Mutations test must actually change things

### DIFF
--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -18,7 +18,7 @@ describe( 'mutations', () => {
 	} );
 
 	it( 'setProperty', () => {
-		const expectedProperty = { id: 'P123', label: 'abc' };
+		const expectedProperty = { id: 'P456', label: 'def' };
 		const state: RootState = {
 			conditionRow: {
 				valueData: { value: 'foo' },


### PR DESCRIPTION
The previous mutations test was ineffective as it did not actually change the content of the store. It now does.