### PR TITLE
Fix TS error in tests

### DIFF
--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -10,6 +10,7 @@ describe( 'getters', () => {
 					valueData: { value: 'foo' },
 					propertyData: { id: 'P123', label: 'abc' },
 				},
+				errors: [],
 			};
 
 			const expectedValue: QueryRepresentation = {


### PR DESCRIPTION
We introduced concept of errors in state and getters need to have it.

Without it, the npm test fail