### PR TITLE
Fix name of attribute in validate()

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -62,7 +62,7 @@ export default Vue.extend( {
 				return false;
 			}
 
-			if ( !this.property || !this.textInputValue ) {
+			if ( !this.selectedItem || !this.textInputValue ) {
 				this.errors.push( {
 					message: 'One or more fields are empty. Please complete the query or select a fitting field type.',
 					type: 'error',


### PR DESCRIPTION
The attribute is now renamed to selectedItem but this got messed up in
rebase. I also don't think the name is quite correct but that's for
another patch. Let's make tests green again.