### PR TITLE
Add compiling TypeScript types to tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "test:lint": "vue-cli-service lint --no-fix --max-warning 0",
-    "test": "npm-run-all test:*",
+    "test": "npm-run-all test:* && vue-cli-service build",
     "test:lintcss": "stylelint '**/*.vue'",
     "fix:css": "stylelint '**/*.vue' --fix",
     "fix:ts": "vue-cli-service lint"


### PR DESCRIPTION
We had bugs and build failures that could have been prevented by this
run.