### PR TITLE
Fix validator of property values

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -60,7 +60,7 @@ export default Vue.extend( {
 		validate(): boolean {
 			this.errors = [];
 			this.$store.dispatch( 'setErrors', [] );
-			if ( !this.selectedProperty.id && !this.textInputValue ) {
+			if ( !this.selectedProperty && !this.textInputValue ) {
 				this.errors.push( {
 					// eslint-disable-next-line max-len
 					message: 'Looks like the Query Builder was empty, please enter a valid query first, then try running it again',
@@ -69,8 +69,8 @@ export default Vue.extend( {
 				return false;
 			}
 
-			if ( !this.selectedProperty.id || !this.textInputValue ) {
-				if ( !this.selectedProperty.id ) {
+			if ( !this.selectedProperty || !this.textInputValue ) {
+				if ( !this.selectedProperty ) {
 					this.fieldErrors.property = {
 						message: 'Please select a property',
 						type: 'error',
@@ -103,7 +103,9 @@ export default Vue.extend( {
 	},
 	computed: {
 		selectedProperty: {
-			get(): Property { return this.$store.getters.property; },
+			get(): Property | null {
+				return this.$store.getters.property;
+			},
 			set( selectedProperty: SearchResult ): void {
 				this.$store.dispatch( 'updateProperty', selectedProperty );
 			},

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -10,7 +10,7 @@
 			<h2 class="querybuilder__find-title">Find all items...</h2>
 			<div class="querybuilder__rule">
 				<PropertyLookup
-					v-model="selectedItem"
+					v-model="selectedProperty"
 					:error="fieldErrors.property"
 				/>
 				<TextInput
@@ -60,7 +60,7 @@ export default Vue.extend( {
 		validate(): boolean {
 			this.errors = [];
 			this.$store.dispatch( 'setErrors', [] );
-			if ( !this.selectedItem && !this.textInputValue ) {
+			if ( !this.selectedProperty.id && !this.textInputValue ) {
 				this.errors.push( {
 					// eslint-disable-next-line max-len
 					message: 'Looks like the Query Builder was empty, please enter a valid query first, then try running it again',
@@ -69,8 +69,8 @@ export default Vue.extend( {
 				return false;
 			}
 
-			if ( !this.selectedItem || !this.textInputValue ) {
-				if ( !this.selectedItem ) {
+			if ( !this.selectedProperty.id || !this.textInputValue ) {
+				if ( !this.selectedProperty.id ) {
 					this.fieldErrors.property = {
 						message: 'Please select a property',
 						type: 'error',
@@ -102,10 +102,10 @@ export default Vue.extend( {
 		},
 	},
 	computed: {
-		selectedItem: {
+		selectedProperty: {
 			get(): Property { return this.$store.getters.property; },
-			set( selectedItem: SearchResult ): void {
-				this.$store.dispatch( 'updateProperty', selectedItem );
+			set( selectedProperty: SearchResult ): void {
+				this.$store.dispatch( 'updateProperty', selectedProperty );
 			},
 		},
 		textInputValue: {

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -12,7 +12,10 @@ export default {
 			},
 		};
 	},
-	property( rootState: RootState ): Property {
+	property( rootState: RootState ): Property | null {
+		if ( !rootState.conditionRow.propertyData.id ) {
+			return null;
+		}
 		return rootState.conditionRow.propertyData;
 	},
 	value( rootState: RootState ): string {


### PR DESCRIPTION
Currently, if the property is empty, the property returns an empty
object that has "id" property and we can check against that instead.

Without this patch, it thinks the property is filled all the time.

Also, renaming the property to its correct name.