### PR TITLE
Move out validation logic out of QueryBuilder component

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -43,7 +43,7 @@ import SearchResult from '@/data-access/SearchResult';
 import Property from '@/data-model/Property';
 import Error from '@/data-model/Error';
 import buildQuery from '@/sparql/buildQuery';
-import Validator, { ValidationResult } from '@/form/Validator';
+import Validator from '@/form/Validator';
 
 export default Vue.extend( {
 	name: 'QueryBuilder',
@@ -58,7 +58,7 @@ export default Vue.extend( {
 		};
 	},
 	methods: {
-		validate(): ValidationResult {
+		validate(): void {
 			const formValues = {
 				property: this.selectedProperty,
 				value: this.textInputValue,
@@ -68,11 +68,10 @@ export default Vue.extend( {
 			this.errors = validationResult.formErrors;
 			this.$store.dispatch( 'setErrors', validationResult.formErrors );
 			this.fieldErrors = validationResult.fieldErrors;
-			return validationResult;
 		},
 		runQuery(): void {
-			const validationResult = this.validate();
-			if ( validationResult.formErrors.length ) {
+			this.validate();
+			if ( this.errors.length ) {
 				return;
 			}
 			this.encodedQuery = encodeURI( buildQuery( this.$store.getters.query ) );

--- a/src/form/FormValues.ts
+++ b/src/form/FormValues.ts
@@ -1,0 +1,12 @@
+import Property from '@/data-model/Property';
+import Error from '@/data-model/Error';
+
+export default interface FormValues {
+	property: Property | null;
+	value: string | null;
+}
+
+export interface FieldErrors {
+	property: Error | null;
+	value: Error | null;
+}

--- a/src/form/Validator.ts
+++ b/src/form/Validator.ts
@@ -1,0 +1,53 @@
+import FormValues, { FieldErrors } from '@/form/FormValues';
+import Error from '@/data-model/Error';
+
+export interface ValidationResult {
+	formErrors: Error[];
+	fieldErrors: FieldErrors;
+}
+
+export default class Validator {
+	private readonly formValues: FormValues;
+	public constructor( formValues: FormValues ) {
+		this.formValues = formValues;
+	}
+
+	public validate(): ValidationResult {
+		const validationResult: ValidationResult = {
+			formErrors: [],
+			fieldErrors: {
+				property: null,
+				value: null,
+			},
+		};
+
+		if ( !this.formValues.property && !this.formValues.value ) {
+			validationResult.formErrors.push( {
+				// eslint-disable-next-line max-len
+				message: 'Looks like the Query Builder was empty, please enter a valid query first, then try running it again',
+				type: 'notice',
+			} );
+			return validationResult;
+		}
+
+		if ( !this.formValues.property || !this.formValues.value ) {
+			if ( !this.formValues.property ) {
+				validationResult.fieldErrors.property = {
+					message: 'Please select a property',
+					type: 'error',
+				};
+			}
+			if ( !this.formValues.value ) {
+				validationResult.fieldErrors.value = {
+					message: 'Please enter a value',
+					type: 'error',
+				};
+			}
+			validationResult.formErrors.push( {
+				message: 'One or more fields are empty. Please complete the query or select a fitting field type.',
+				type: 'error',
+			} );
+		}
+		return validationResult;
+	}
+}

--- a/tests/unit/form/Validator.spec.ts
+++ b/tests/unit/form/Validator.spec.ts
@@ -2,7 +2,7 @@ import FormValues from '@/form/FormValues';
 import Validator, { ValidationResult } from '@/form/Validator';
 
 describe( 'validator', () => {
-	it( 'full form', () => {
+	it( 'returns no errors with a complete form', () => {
 		const formValues: FormValues = {
 			property: {
 				id: 'P31',

--- a/tests/unit/form/Validator.spec.ts
+++ b/tests/unit/form/Validator.spec.ts
@@ -24,7 +24,7 @@ describe( 'validator', () => {
 		expect( validator.validate() ).toStrictEqual( expectedResult );
 	} );
 
-	it( 'property missing', () => {
+	it( 'returns one error with a property missing', () => {
 		const formValues: FormValues = {
 			property: null,
 			value: 'Q5',
@@ -47,7 +47,7 @@ describe( 'validator', () => {
 
 	} );
 
-	it( 'value missing', () => {
+	it( 'returns one error with a value missing', () => {
 		const formValues: FormValues = {
 			property: {
 				id: 'P31',
@@ -72,7 +72,7 @@ describe( 'validator', () => {
 		expect( validationResult.fieldErrors.value ).toHaveProperty( 'type' );
 	} );
 
-	it( 'empty form', () => {
+	it( 'returns notice when the form is empty', () => {
 		const formValues: FormValues = {
 			property: null,
 			value: null,

--- a/tests/unit/form/Validator.spec.ts
+++ b/tests/unit/form/Validator.spec.ts
@@ -1,0 +1,95 @@
+import FormValues from '@/form/FormValues';
+import Validator, { ValidationResult } from '@/form/Validator';
+
+describe( 'validator', () => {
+	it( 'full form', () => {
+		const formValues: FormValues = {
+			property: {
+				id: 'P31',
+				label: 'instance of',
+			},
+			value: 'Q5',
+		};
+
+		const expectedResult: ValidationResult = {
+			formErrors: [],
+			fieldErrors: {
+				property: null,
+				value: null,
+			},
+		};
+
+		const validator = new Validator( formValues );
+
+		expect( validator.validate() ).toStrictEqual( expectedResult );
+	} );
+
+	it( 'property missing', () => {
+		const formValues: FormValues = {
+			property: null,
+			value: 'Q5',
+		};
+
+		const formErrors = [
+			{
+				type: 'error',
+			},
+		];
+
+		const validator = new Validator( formValues );
+		const validationResult = validator.validate();
+
+		expect( validationResult.formErrors ).toHaveLength( 1 );
+		expect( validationResult.formErrors[ 0 ].type ).toBe( formErrors[ 0 ].type );
+		expect( validationResult.fieldErrors.property ).not.toBeNull();
+		expect( validationResult.fieldErrors.value ).toBeNull();
+		expect( validationResult.fieldErrors.property ).toHaveProperty( 'type' );
+
+	} );
+
+	it( 'value missing', () => {
+		const formValues: FormValues = {
+			property: {
+				id: 'P31',
+				label: 'instance of',
+			},
+			value: null,
+		};
+
+		const formErrors = [
+			{
+				type: 'error',
+			},
+		];
+
+		const validator = new Validator( formValues );
+		const validationResult = validator.validate();
+
+		expect( validationResult.formErrors ).toHaveLength( 1 );
+		expect( validationResult.formErrors[ 0 ].type ).toBe( formErrors[ 0 ].type );
+		expect( validationResult.fieldErrors.property ).toBeNull();
+		expect( validationResult.fieldErrors.value ).not.toBeNull();
+		expect( validationResult.fieldErrors.value ).toHaveProperty( 'type' );
+	} );
+
+	it( 'empty form', () => {
+		const formValues: FormValues = {
+			property: null,
+			value: null,
+		};
+
+		const formErrors = [
+			{
+				type: 'notice',
+			},
+		];
+
+		const validator = new Validator( formValues );
+		const validationResult = validator.validate();
+
+		expect( validationResult.formErrors ).toHaveLength( 1 );
+		expect( validationResult.formErrors[ 0 ].type ).toBe( formErrors[ 0 ].type );
+		expect( validationResult.fieldErrors.property ).toBeNull();
+		expect( validationResult.fieldErrors.value ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
This is business logic and should not exist there and the component is
already getting really big.

Also, introducing several interfaces to formalize relationship of
components and business domain.