### PR TITLE
Add ability to change language with uselang=foo

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-	<div id="app">
+	<div id="app" :lang="lang" dir="auto">
 		<QueryBuilder v-if="isi18nLoaded"/>
 	</div>
 </template>
@@ -13,21 +13,44 @@ export default Vue.extend( {
 	data() {
 		return {
 			isi18nLoaded: false as boolean,
+			lang: 'en' as string,
 		};
 	},
-	beforeCreate(): void {
+	created(): void {
 		const fetchi18n = async (): Promise<void> => {
-			const response = await fetch( 'i18n/en.json' );
-			const messages = {
-				en: await response.json(),
+			const urlParams = new URLSearchParams( window.location.search );
+			if ( urlParams.has( 'uselang' ) ) {
+				this.lang = urlParams.get( 'uselang' ) as string;
+			}
+
+			const responseEn = await fetch( 'i18n/en.json' );
+			const messages: { [key: string]: { [key: string]: string} } = {
+				en: await responseEn.json(),
 			};
+
+			if ( this.lang !== 'en' ) {
+				const responseLang = await fetch( 'i18n/' + this.lang + '.json' ).catch(
+					() => {
+						// TODO: Show a user-facing notification instead
+						console.warn( 'The language requested could not be retrieved, falling back to English' );
+						messages[ this.lang ] = {};
+					},
+				) as Response;
+				if ( responseLang.ok ) {
+					try {
+						messages[ this.lang ] = await responseLang.json();
+					} catch ( e ) {
+						console.warn( 'The language requested does not exist, falling back to English' );
+					}
+				}
+			}
+
 			Vue.use( i18n, {
-				locale: 'en',
+				locale: this.lang,
 				messages,
 				wikilinks: true,
 			} );
-			// TODO: Fix the typing warning
-			( this as any ).isi18nLoaded = true;
+			this.isi18nLoaded = true;
 		};
 
 		fetchi18n();

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,19 +29,13 @@ export default Vue.extend( {
 			};
 
 			if ( this.lang !== 'en' ) {
-				const responseLang = await fetch( 'i18n/' + this.lang + '.json' ).catch(
-					() => {
-						// TODO: Show a user-facing notification instead
-						console.warn( 'The language requested could not be retrieved, falling back to English' );
-						messages[ this.lang ] = {};
-					},
-				) as Response;
-				if ( responseLang.ok ) {
-					try {
-						messages[ this.lang ] = await responseLang.json();
-					} catch ( e ) {
-						console.warn( 'The language requested does not exist, falling back to English' );
-					}
+				try {
+					const responseLang = await fetch( 'i18n/' + this.lang + '.json' );
+					messages[ this.lang ] = await responseLang.json();
+				} catch ( e ) {
+					// TODO: Show a user-facing notification instead
+					console.warn( 'The language requested could not be retrieved, falling back to English' );
+					messages[ this.lang ] = {};
 				}
 			}
 

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -6,7 +6,7 @@
 			Welcome to the test system of the Simple Query Builder. Please note that this is a work in progress,
 			not all features are included, and it can sometimes be broken.
 			<a href="https://w.wiki/kG$">Feedback is welcome here.</a>
-		</p>>
+		</p>
 		<div role="form">
 			<h2 class="querybuilder__find-title"
 				v-i18n="{msg: 'query-builder-find-all-items'}" />


### PR DESCRIPTION
 - Fixing type error by changing the hook to created() so the data would
   be available
 - Handing cases where the response is non-existent or not parsable
 - Requesting English regardless since it needs to fall back if a
   certain message doesn't exist in that language
 - Using uselang= to make it consistent with rest of Wikimedia
   applications

Bug: T267732