### PR TITLE
Adjust Query Representation and SPARQL Query for without state

### DIFF
--- a/src/data-model/PropertyValueRelation.ts
+++ b/src/data-model/PropertyValueRelation.ts
@@ -1,5 +1,6 @@
 enum PropertyValueRelation {
 	Matching = 'matching',
+	NotMatching = 'without',
 	Regardless = 'regardless of value',
 }
 

--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -1,6 +1,6 @@
 import rdfNamespaces from '@/sparql/rdfNamespaces';
 import QueryRepresentation from '@/sparql/QueryRepresentation';
-import { SelectQuery, Term } from 'sparqljs';
+import { Pattern, SelectQuery, Term } from 'sparqljs';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 
 export default class QueryObjectBuilder {
@@ -32,6 +32,12 @@ export default class QueryObjectBuilder {
 				tripleObject = {
 					termType: 'Literal',
 					value: queryRepresentation.condition.value,
+				};
+				break;
+			case ( PropertyValueRelation.NotMatching ):
+				tripleObject = {
+					termType: 'Variable',
+					value: 'instance',
 				};
 				break;
 			case ( PropertyValueRelation.Regardless ):
@@ -72,6 +78,28 @@ export default class QueryObjectBuilder {
 				],
 			},
 		];
+
+		if ( queryRepresentation.condition.propertyValueRelation === PropertyValueRelation.NotMatching ) {
+			const filterCondition = {
+				type: 'filter',
+				expression: {
+					type: 'operation',
+					operator: '!=',
+					args: [
+						{
+							termType: 'Variable',
+							value: 'instance',
+						},
+						{
+							termType: 'Literal',
+							value: queryRepresentation.condition.value,
+						},
+					],
+				},
+			};
+
+			this.queryObject.where.push( filterCondition as Pattern );
+		}
 
 		return this.queryObject;
 	}

--- a/tests/unit/sparql/buildQuery.spec.ts
+++ b/tests/unit/sparql/buildQuery.spec.ts
@@ -14,6 +14,26 @@ describe( 'buildQuery', () => {
 		} } ) ).toEqual( `SELECT ?item WHERE { ?item (p:${propertyId}/ps:${propertyId}) "${value}". }` );
 	} );
 
+	it( 'builds a query from a property and a string value with not matching selected', () => {
+		const propertyId = 'P666';
+		const value = 'blah';
+		const propertyValueRelation = PropertyValueRelation.NotMatching;
+
+		const expectedQuery =
+			`SELECT ?item WHERE {
+			?item (p:${propertyId}/ps:${propertyId}) ?instance.
+			FILTER(?instance != "${value}")
+			}`;
+
+		const receivedQuery = buildQuery( { condition: {
+			propertyId,
+			value,
+			propertyValueRelation,
+		} } );
+
+		expect( receivedQuery.replace( /\s+/g, ' ' ) ).toEqual( expectedQuery.replace( /\s+/g, ' ' ) );
+	} );
+
 	it( 'builds a query from a property with "any value" selected', () => {
 		const propertyId = 'P666';
 		const propertyValueRelation = PropertyValueRelation.Regardless;


### PR DESCRIPTION
Accidentally worked on this before the ticket was pulled into the sprint. Will leave here for next week

+ added without state to enum
+ modified QueryRepresentation by adding without state
+ added test to verify that query is being generated correctly
