### PR TITLE
Disable Input field depending on state of ValueTypeDropdown

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -25,7 +25,9 @@
 					v-model="textInputValue"
 					:error="fieldErrors.value ?
 						{message: $i18n(fieldErrors.value.message), type: fieldErrors.value.type}: null"
-					:placeholder="$i18n('query-builder-input-value-placeholder')" />
+					:placeholder="$i18n('query-builder-input-value-placeholder')"
+					:disabled="selectedPropertyValueRelation === propertyValueRelation.Regardless"
+				/>
 			</div>
 			<div class="querybuilder__run">
 				<Button
@@ -66,6 +68,8 @@ export default Vue.extend( {
 				property: null as null | Error,
 				value: null as null | Error,
 			},
+			selectedOption: '',
+			propertyValueRelation: PropertyValueRelation,
 		};
 	},
 	methods: {
@@ -73,7 +77,7 @@ export default Vue.extend( {
 			const formValues = {
 				property: this.selectedProperty,
 				value: this.textInputValue,
-				relation: this.selectedPropertyValueRelation,
+				propertyValueRelation: this.selectedPropertyValueRelation,
 			};
 			const validator = new Validator( formValues );
 			const validationResult = validator.validate();
@@ -105,7 +109,10 @@ export default Vue.extend( {
 			get(): PropertyValueRelation {
 				return this.$store.getters.propertyValueRelation;
 			},
-			set( selectedPropertyValueRelation: string ): void {
+			set( selectedPropertyValueRelation: PropertyValueRelation ): void {
+				if ( selectedPropertyValueRelation === PropertyValueRelation.Regardless ) {
+					this.textInputValue = '';
+				}
 				this.$store.dispatch( 'updatePropertyValueRelation', selectedPropertyValueRelation );
 			},
 		},

--- a/src/components/ValueTypeDropDown.vue
+++ b/src/components/ValueTypeDropDown.vue
@@ -22,7 +22,7 @@ export default Vue.extend( {
 	name: 'ValueTypeDropDown',
 	data() {
 		return {
-			selected: '',
+			selected: PropertyValueRelation.Matching,
 			optionItems: PropertyValueRelation,
 		};
 	},

--- a/src/form/FormValues.ts
+++ b/src/form/FormValues.ts
@@ -1,9 +1,11 @@
 import Property from '@/data-model/Property';
 import Error from '@/data-model/Error';
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 
 export default interface FormValues {
 	property: Property | null;
 	value: string | null;
+	propertyValueRelation: PropertyValueRelation;
 }
 
 export interface FieldErrors {

--- a/src/form/Validator.ts
+++ b/src/form/Validator.ts
@@ -1,4 +1,5 @@
 import FormValues, { FieldErrors } from '@/form/FormValues';
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import Error from '@/data-model/Error';
 
 export interface ValidationResult {
@@ -29,24 +30,26 @@ export default class Validator {
 			return validationResult;
 		}
 
-		if ( !this.formValues.property || !this.formValues.value ) {
-			if ( !this.formValues.property ) {
-				validationResult.fieldErrors.property = {
-					message: 'query-builder-result-error-missing-property',
-					type: 'error',
-				};
-			}
-			if ( !this.formValues.value ) {
-				validationResult.fieldErrors.value = {
-					message: 'query-builder-result-error-missing-value',
-					type: 'error',
-				};
-			}
+		if ( !this.formValues.property ) {
+			validationResult.fieldErrors.property = {
+				message: 'query-builder-result-error-missing-property',
+				type: 'error',
+			};
+		}
+		if ( !( this.formValues.propertyValueRelation === PropertyValueRelation.Regardless ) &&
+		!this.formValues.value ) {
+			validationResult.fieldErrors.value = {
+				message: 'query-builder-result-error-missing-value',
+				type: 'error',
+			};
+		}
+		if ( validationResult.fieldErrors.property || validationResult.fieldErrors.value ) {
 			validationResult.formErrors.push( {
 				message: 'query-builder-result-error-incomplete-form',
 				type: 'error',
 			} );
 		}
+
 		return validationResult;
 	}
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -4,6 +4,7 @@ import SearchEntityRepository from '@/data-access/SearchEntityRepository';
 import SearchResult from '@/data-access/SearchResult';
 import Error from '@/data-model/Error';
 import Property from '@/data-model/Property';
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 
 // eslint-disable-next-line max-len
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
@@ -18,7 +19,8 @@ export default ( searchEntityRepository: SearchEntityRepository ) => ( {
 	updateProperty( context: ActionContext<RootState, RootState>, property: Property ): void {
 		context.commit( 'setProperty', property );
 	},
-	updatePropertyValueRelation( context: ActionContext<RootState, RootState>, propertyValueRelation: string ): void {
+	updatePropertyValueRelation( context: ActionContext<RootState, RootState>,
+		propertyValueRelation: PropertyValueRelation ): void {
 		context.commit( 'setPropertyValueRelation', propertyValueRelation );
 	},
 	setErrors( context: ActionContext<RootState, RootState>, errors: Error[] ): void {

--- a/tests/unit/form/Validator.spec.ts
+++ b/tests/unit/form/Validator.spec.ts
@@ -1,5 +1,6 @@
 import FormValues from '@/form/FormValues';
 import Validator, { ValidationResult } from '@/form/Validator';
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 
 describe( 'validator', () => {
 	it( 'returns no errors with a complete form', () => {
@@ -9,6 +10,7 @@ describe( 'validator', () => {
 				label: 'instance of',
 			},
 			value: 'Q5',
+			propertyValueRelation: PropertyValueRelation.Matching,
 		};
 
 		const expectedResult: ValidationResult = {
@@ -28,6 +30,7 @@ describe( 'validator', () => {
 		const formValues: FormValues = {
 			property: null,
 			value: 'Q5',
+			propertyValueRelation: PropertyValueRelation.Matching,
 		};
 
 		const expectedResult: ValidationResult = {
@@ -52,13 +55,14 @@ describe( 'validator', () => {
 
 	} );
 
-	it( 'returns one error with a value missing', () => {
+	it( 'returns one error with a value missing when PropertyValueRelation = Matching', () => {
 		const formValues: FormValues = {
 			property: {
 				id: 'P31',
 				label: 'instance of',
 			},
 			value: null,
+			propertyValueRelation: PropertyValueRelation.Matching,
 		};
 
 		const expectedResult: ValidationResult = {
@@ -82,10 +86,34 @@ describe( 'validator', () => {
 		expect( validator.validate() ).toStrictEqual( expectedResult );
 	} );
 
+	it( 'returns no errors with a value missing when PropertyValueRelation = Regardless', () => {
+		const formValues: FormValues = {
+			property: {
+				id: 'P31',
+				label: 'instance of',
+			},
+			value: null,
+			propertyValueRelation: PropertyValueRelation.Regardless,
+		};
+
+		const expectedResult: ValidationResult = {
+			formErrors: [],
+			fieldErrors: {
+				property: null,
+				value: null,
+			},
+		};
+
+		const validator = new Validator( formValues );
+
+		expect( validator.validate() ).toStrictEqual( expectedResult );
+	} );
+
 	it( 'returns notice when the form is empty', () => {
 		const formValues: FormValues = {
 			property: null,
 			value: null,
+			propertyValueRelation: PropertyValueRelation.Matching,
 		};
 
 		const expectedResult: ValidationResult = {


### PR DESCRIPTION
- updated validator to not throw error on missing value when regarless is chosen
- wired valuetextinput to ValueTypeDropdown
- updated Validator to include propertyValueRelation
- added test for form validator to check for missing value in case of regardless
and matching

it is based on [PR 69](https://github.com/wmde/query-builder/pull/69). Will rebase once it is finished and merged.