### PR TITLE
Fix ValueTypeDropDown test

### DIFF
--- a/tests/unit/components/ValueTypeDropDown.spec.ts
+++ b/tests/unit/components/ValueTypeDropDown.spec.ts
@@ -13,6 +13,8 @@ describe( 'ValueTypeDropDown.vue', () => {
 			optionItems: optionItems,
 		} );
 
+		wrapper.findComponent( ValueTypeDropDown ).vm.$emit( 'input', optionItems.Matching );
+
 		await Vue.nextTick();
 
 		expect( wrapper.emitted( 'input' )![ 0 ][ 0 ] ).toEqual( optionItems.Matching );


### PR DESCRIPTION
The ValueTypeDropdown test should not have passed when it was first
pushed. It failed in the next PR, though.

Adding the event emitter as a fix