### PR TITLE
Use specialized method to select an <option> in test

### DIFF
--- a/tests/unit/components/ValueTypeDropDown.spec.ts
+++ b/tests/unit/components/ValueTypeDropDown.spec.ts
@@ -8,15 +8,10 @@ describe( 'ValueTypeDropDown.vue', () => {
 		const optionItems = PropertyValueRelation;
 		const wrapper = shallowMount( ValueTypeDropDown );
 
-		wrapper.setData( {
-			selected: optionItems.Matching,
-			optionItems: optionItems,
-		} );
-
-		wrapper.findComponent( ValueTypeDropDown ).vm.$emit( 'input', optionItems.Matching );
+		wrapper.find( `option[value="${optionItems.Regardless}"]` ).setSelected();
 
 		await Vue.nextTick();
 
-		expect( wrapper.emitted( 'input' )![ 0 ][ 0 ] ).toEqual( optionItems.Matching );
+		expect( wrapper.emitted( 'input' )![ 0 ][ 0 ] ).toEqual( optionItems.Regardless );
 	} );
 } );


### PR DESCRIPTION
~~The setSelected() method was added in vuejs/vue-test-utils#557, but apparently never documented. It seems stable and intended for end-user use nonetheless, so it is probably just an oversight documentation wise.~~ The `setSelected()` is actually documented in https://vue-test-utils.vuejs.org/api/wrapper/#setselected -- no idea why I didn't find it when I first looked.

This PR should make the test last touched in #72 more robust