### PR TITLE
Fix rootState error for propertyData being undefined

### DIFF
--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -15,7 +15,7 @@ export default {
 		};
 	},
 	property( rootState: RootState ): Property | null {
-		if ( !rootState.conditionRow.propertyData.id ) {
+		if ( !rootState.conditionRow.propertyData?.id ) {
 			return null;
 		}
 		return rootState.conditionRow.propertyData;


### PR DESCRIPTION
Currently, if you try looking up a property, in the on-air moment, it
starts to emit lots of error since the property is not yet selected and
is undefined. This would fix the error.