### PR TITLE
Fix banana tests

### DIFF
--- a/tests/unit/i18n/banana.spec.ts
+++ b/tests/unit/i18n/banana.spec.ts
@@ -27,6 +27,9 @@ describe( 'banana tests', () => {
 		}
 
 		for ( messageKey in messages.qqq ) {
+			if ( messageKey === '@metadata' ) {
+				continue;
+			}
 			expect( messages.en[ messageKey ] ).toBeTruthy();
 		}
 	} );


### PR DESCRIPTION
Translatewiki bot adds "@metadata" key in qqq.json that doesn't exist in
en.json and the test mistakenly takes it as an orphan description and
error out. Ignoring that particular key.