### PR TITLE
Add CI-Job to track pull request code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,24 @@
+name: Jest Code Coverage
+
+on: pull_request
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+      - name: Install
+        run: npm ci
+      - name: coverage
+        uses: mattallty/jest-github-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          test-command: "npm run test:unit -- --coverage"
+
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,4 +3,5 @@ module.exports = {
 	transformIgnorePatterns: [
 		'<rootDir>/node_modules/(?!(@wmde/wikit-vue-components)/)',
 	],
+	coverageReporters: [ 'lcov', 'text' ],
 };


### PR DESCRIPTION
This (https://github.com/mattallty/jest-github-action) seems to be the most-used action that does not depend on an external service.

This has only a "run on changed code only" option, not sure if would benefit from that.