### PR TITLE
Fix changes in query in state

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -37,6 +37,7 @@ import QueryResult from '@/components/QueryResult.vue';
 import buildQuery from '@/sparql/buildQuery';
 import Validator from '@/form/Validator';
 import AddCondition from '@/components/AddCondition.vue';
+import { Condition } from '@/sparql/QueryRepresentation';
 
 export default ( Vue as VueConstructor<Vue & { $refs: { condition: InstanceType<typeof QueryCondition> } }> ).extend( {
 	name: 'QueryBuilder',
@@ -55,12 +56,14 @@ export default ( Vue as VueConstructor<Vue & { $refs: { condition: InstanceType<
 		},
 		validate(): void {
 			// TODO: Clean up FormValue <-> Query relation
-			const formValues = {
-				property: this.$store.getters.query.condition.propertyId,
-				value: this.$store.getters.query.condition.value,
-				propertyValueRelation: this.$store.getters.query.condition.propertyValueRelation,
-			};
-			const validator = new Validator( formValues );
+			const formValues = this.$store.getters.query.conditions.map( ( condition: Condition ) => {
+				return {
+					property: condition.propertyId,
+					value: condition.value,
+					propertyValueRelation: condition.propertyValueRelation,
+				};
+			} );
+			const validator = new Validator( formValues[ 0 ] );
 			const validationResult = validator.validate();
 			this.errors = validationResult.formErrors;
 			this.$store.dispatch( 'setErrors', validationResult.formErrors );


### PR DESCRIPTION
Without it, the run query button just stops working since validator is
not getting the right FormValues object

I think this was an implicit rebase issue that was overlooked.

For later, we should rework the validation to handle multiple condition
rows.