### PR TITLE
Move unsupported data types out of the allowed list

### DIFF
--- a/src/allowedDataTypes.ts
+++ b/src/allowedDataTypes.ts
@@ -1,14 +1,14 @@
 const allowedDataTypes = [
 	/* string typed datatypes */
+	'string',
+	'external-id',
+	/* other (non-string) typed datatypes - TODO: add support
 	'commonsMedia',
 	'geo-shape',
-	'string',
 	'tabular-data',
 	'url',
-	'external-id',
-	'musical-notation',
 	'math',
-	/* other (non-string) typed datatypes - TODO: add support
+	'musical-notation',
     'time',
 	'globe-coordinate',
 	'monolingualtext',


### PR DESCRIPTION
They use a different RdfBuilder meaning the values wouldn't be matched.
We should be able to have better support later

Bug: T269439