### PR TITLE
added methods searchEntities and searchItemValues

### DIFF
--- a/src/data-access/FetchSearchEntityRepository.ts
+++ b/src/data-access/FetchSearchEntityRepository.ts
@@ -11,13 +11,13 @@ export default class FetchSearchEntityRepository implements SearchEntityReposito
 		this.endpoint = endpoint;
 	}
 
-	public async searchProperties( searchString: string, limit?: number, offset?: number ):
+	private async searchEntities( searchString: string, entityType: string, limit?: number, offset?: number ):
 	Promise<SearchResult[]> {
 		const params: { [key: string]: string } = {
 			action: 'wbsearchentities',
 			search: searchString,
 			language: this.forLanguageCode,
-			type: 'property',
+			type: entityType,
 			format: 'json',
 			formatversion: '2',
 			errorformat: 'plaintext',
@@ -48,5 +48,13 @@ export default class FetchSearchEntityRepository implements SearchEntityReposito
 		const data = await response.json();
 
 		return data.search;
+	}
+
+	public searchProperties( searchString: string, limit?: number, offset?: number ): Promise<SearchResult[]> {
+		return this.searchEntities( searchString, 'property', limit, offset );
+	}
+
+	public searchItemValues( searchString: string, limit?: number, offset?: number ): Promise<SearchResult[]> {
+		return this.searchEntities( searchString, 'item', limit, offset );
 	}
 }

--- a/src/data-access/SearchEntityRepository.ts
+++ b/src/data-access/SearchEntityRepository.ts
@@ -6,4 +6,5 @@ import SearchResult from './SearchResult';
  */
 export default interface SearchEntityRepository {
 	searchProperties( searchString: string, limit?: number, offset?: number ): Promise<SearchResult[]>;
+	searchItemValues( searchString: string, limit?: number, offset?: number ): Promise<SearchResult[]>;
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -25,6 +25,15 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 			return searchResult;
 		} );
 	},
+	async searchItemValues(
+		_context: ActionContext<RootState, RootState>,
+		options: SearchOptions ): Promise<SearchResult[]> {
+		// check for empty
+		const searchResults = await searchEntityRepository.searchItemValues( options.search, 12, options.offset );
+		return searchResults.map( ( searchResult: MenuItem & SearchResult ) => {
+			return searchResult;
+		} );
+	},
 	updateValue(
 		context: ActionContext<RootState, RootState>,
 		payload: { value: string; conditionIndex: number } ): void {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -29,10 +29,7 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 		_context: ActionContext<RootState, RootState>,
 		options: SearchOptions ): Promise<SearchResult[]> {
 		// check for empty
-		const searchResults = await searchEntityRepository.searchItemValues( options.search, 12, options.offset );
-		return searchResults.map( ( searchResult: MenuItem & SearchResult ) => {
-			return searchResult;
-		} );
+		return await searchEntityRepository.searchItemValues( options.search, 12, options.offset );
 	},
 	updateValue(
 		context: ActionContext<RootState, RootState>,

--- a/tests/unit/data-access/FetchSearchEntityRepository.spec.ts
+++ b/tests/unit/data-access/FetchSearchEntityRepository.spec.ts
@@ -175,34 +175,26 @@ describe( 'FetchSearchEntityRepository', () => {
 		expect( repo.searchItemValues( 'John Smith' ) ).rejects.toThrow( expectedError );
 	} );
 
-	it( 'throws an error if there is a server side problem fetching a property', () => {
+	it( 'throws an error if there is a network problem fetching a property', () => {
 		const repo = new FetchSearchEntityRepository(
 			'eo',
 			'https://example.com/w/api.php',
 		);
-		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
-			ok: false,
-			status: 500,
-			statusText: 'Server Error',
-		} ) );
+		window.fetch = jest.fn().mockImplementation( () => Promise.reject() );
 
-		const expectedError = new TechnicalProblem( '500: Server Error' );
+		const expectedError = new TechnicalProblem( 'Network error' );
 
 		expect( repo.searchProperties( 'instance' ) ).rejects.toThrow( expectedError );
 	} );
 
-	it( 'throws an error if there is a server side problem fetching an item', () => {
+	it( 'throws an error if there is a network problem fetching an item value', () => {
 		const repo = new FetchSearchEntityRepository(
 			'eo',
 			'https://example.com/w/api.php',
 		);
-		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
-			ok: false,
-			status: 500,
-			statusText: 'Server Error',
-		} ) );
+		window.fetch = jest.fn().mockImplementation( () => Promise.reject() );
 
-		const expectedError = new TechnicalProblem( '500: Server Error' );
+		const expectedError = new TechnicalProblem( 'Network error' );
 
 		expect( repo.searchItemValues( 'John Smith' ) ).rejects.toThrow( expectedError );
 	} );

--- a/tests/unit/data-access/FetchSearchEntityRepository.spec.ts
+++ b/tests/unit/data-access/FetchSearchEntityRepository.spec.ts
@@ -73,7 +73,77 @@ describe( 'FetchSearchEntityRepository', () => {
 		expect( window.fetch ).toHaveBeenCalledWith( expectedUrl );
 	} );
 
-	it( 'throws an error if there is a server side problem', () => {
+	it( 'searches for item values with default values', async () => {
+		const testLang = 'eo';
+		const testEndpoint = 'https://example.com/w/api.php';
+		const repo = new FetchSearchEntityRepository(
+			testLang,
+			testEndpoint,
+		);
+		const testSearchTerm = '"><script>alert(\'XXS!\');</script>';
+		const expectedResult = [ { foo: 'bar' } ];
+
+		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
+			ok: true,
+			json: async () => ( { search: expectedResult } ),
+		} ) );
+
+		const actualResult = await repo.searchItemValues( testSearchTerm );
+
+		const escapedSearch = '%22%3E%3Cscript%3Ealert%28%27XXS%21%27%29%3B%3C%2Fscript%3E';
+		const expectedParams = {
+			action: 'wbsearchentities',
+			search: escapedSearch,
+			language: testLang,
+			type: 'item',
+			format: 'json',
+			formatversion: 2,
+			errorformat: 'plaintext',
+			origin: '*',
+		};
+		const expectedQuery = Object.entries( expectedParams ).map( ( entry ) => entry.join( '=' ) ).join( '&' );
+		const expectedUrl = `${testEndpoint}?${expectedQuery}`;
+		expect( window.fetch ).toHaveBeenCalledTimes( 1 );
+		expect( window.fetch ).toHaveBeenCalledWith( expectedUrl );
+		expect( actualResult ).toBe( expectedResult );
+	} );
+
+	it( 'searches for item values with provided limit and offset', async () => {
+		const testLang = 'eo';
+		const testEndpoint = 'https://example.com/w/api.php';
+		const repo = new FetchSearchEntityRepository(
+			testLang,
+			testEndpoint,
+		);
+		const testSearch = 'instance';
+		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
+			ok: true,
+			json: async () => ( { search: [ { foo: 'bar' } ] } ),
+		} ) );
+		const limit = 12;
+		const offset = 24;
+
+		await repo.searchItemValues( testSearch, limit, offset );
+
+		const expectedParams = {
+			action: 'wbsearchentities',
+			search: testSearch,
+			language: testLang,
+			type: 'item',
+			format: 'json',
+			formatversion: 2,
+			errorformat: 'plaintext',
+			origin: '*',
+			limit,
+			continue: offset,
+		};
+		const expectedQuery = Object.entries( expectedParams ).map( ( entry ) => entry.join( '=' ) ).join( '&' );
+		const expectedUrl = `${testEndpoint}?${expectedQuery}`;
+		expect( window.fetch ).toHaveBeenCalledTimes( 1 );
+		expect( window.fetch ).toHaveBeenCalledWith( expectedUrl );
+	} );
+
+	it( 'throws an error if there is a server side problem fetching a property', () => {
 		const repo = new FetchSearchEntityRepository(
 			'eo',
 			'https://example.com/w/api.php',
@@ -89,16 +159,52 @@ describe( 'FetchSearchEntityRepository', () => {
 		expect( repo.searchProperties( 'instance' ) ).rejects.toThrow( expectedError );
 	} );
 
-	it( 'throws an error if there is a network problem', () => {
+	it( 'throws an error if there is a server side problem fetching an item value', () => {
 		const repo = new FetchSearchEntityRepository(
 			'eo',
 			'https://example.com/w/api.php',
 		);
-		window.fetch = jest.fn().mockImplementation( () => Promise.reject() );
+		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
+			ok: false,
+			status: 500,
+			statusText: 'Server Error',
+		} ) );
 
-		const expectedError = new TechnicalProblem( 'Network error' );
+		const expectedError = new TechnicalProblem( '500: Server Error' );
+
+		expect( repo.searchItemValues( 'John Smith' ) ).rejects.toThrow( expectedError );
+	} );
+
+	it( 'throws an error if there is a server side problem fetching a property', () => {
+		const repo = new FetchSearchEntityRepository(
+			'eo',
+			'https://example.com/w/api.php',
+		);
+		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
+			ok: false,
+			status: 500,
+			statusText: 'Server Error',
+		} ) );
+
+		const expectedError = new TechnicalProblem( '500: Server Error' );
 
 		expect( repo.searchProperties( 'instance' ) ).rejects.toThrow( expectedError );
+	} );
+
+	it( 'throws an error if there is a server side problem fetching an item', () => {
+		const repo = new FetchSearchEntityRepository(
+			'eo',
+			'https://example.com/w/api.php',
+		);
+		window.fetch = jest.fn().mockImplementation( () => Promise.resolve( {
+			ok: false,
+			status: 500,
+			statusText: 'Server Error',
+		} ) );
+
+		const expectedError = new TechnicalProblem( '500: Server Error' );
+
+		expect( repo.searchItemValues( 'John Smith' ) ).rejects.toThrow( expectedError );
 	} );
 
 } );

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -96,7 +96,7 @@ describe( 'actions', () => {
 				JSON.parse( JSON.stringify( expectedResult ) ),
 			);
 			const actions = createActions(
-				{ searchProperties, searchItemValues },
+				{ jest.fn(), searchItemValues },
 				services.get( 'metricsCollector' ),
 			);
 

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -41,11 +41,8 @@ describe( 'actions', () => {
 			const searchProperties = jest.fn().mockResolvedValue(
 				JSON.parse( JSON.stringify( expectedResult ) ),
 			);
-			const searchItemValues = jest.fn().mockResolvedValue(
-				JSON.parse( JSON.stringify( expectedResult ) ),
-			);
 			const actions = createActions(
-				{ searchProperties, searchItemValues },
+				{ searchProperties, searchItemValues: jest.fn() },
 				services.get( 'metricsCollector' ),
 			);
 
@@ -69,13 +66,10 @@ describe( 'actions', () => {
 				},
 			];
 			const searchProperties = jest.fn().mockResolvedValue(
-				JSON.parse( JSON.stringify( searchInput ) ),
-			);
-			const searchItemValues = jest.fn().mockResolvedValue(
-				JSON.parse( JSON.stringify( searchInput ) ),
+				JSON.parse( JSON.stringify( expectedResult ) ),
 			);
 			const actions = createActions(
-				{ searchProperties, searchItemValues },
+				{ searchProperties, searchItemValues: jest.fn() },
 				services.get( 'metricsCollector' ),
 			);
 
@@ -89,14 +83,11 @@ describe( 'actions', () => {
 	describe( 'searchItemValues', () => {
 		it( 'calls the repo and resolves with the result', async () => {
 			const expectedResult = [ { label: 'potato', id: 'Q666', datatype: 'string' } ];
-			const searchProperties = jest.fn().mockResolvedValue(
-				JSON.parse( JSON.stringify( expectedResult ) ),
-			);
 			const searchItemValues = jest.fn().mockResolvedValue(
 				JSON.parse( JSON.stringify( expectedResult ) ),
 			);
 			const actions = createActions(
-				{ jest.fn(), searchItemValues },
+				{ searchProperties: jest.fn(), searchItemValues },
 				services.get( 'metricsCollector' ),
 			);
 

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -41,8 +41,11 @@ describe( 'actions', () => {
 			const searchProperties = jest.fn().mockResolvedValue(
 				JSON.parse( JSON.stringify( expectedResult ) ),
 			);
+			const searchItemValues = jest.fn().mockResolvedValue(
+				JSON.parse( JSON.stringify( expectedResult ) ),
+			);
 			const actions = createActions(
-				{ searchProperties },
+				{ searchProperties, searchItemValues },
 				services.get( 'metricsCollector' ),
 			);
 
@@ -68,14 +71,43 @@ describe( 'actions', () => {
 			const searchProperties = jest.fn().mockResolvedValue(
 				JSON.parse( JSON.stringify( searchInput ) ),
 			);
+			const searchItemValues = jest.fn().mockResolvedValue(
+				JSON.parse( JSON.stringify( searchInput ) ),
+			);
 			const actions = createActions(
-				{ searchProperties },
+				{ searchProperties, searchItemValues },
 				services.get( 'metricsCollector' ),
 			);
 
 			const searchOptions: SearchOptions = { search: 'postal', limit: 12 };
 			const actualResult = await actions.searchProperties( {} as any, searchOptions );
 
+			expect( actualResult ).toStrictEqual( expectedResult );
+		} );
+	} );
+
+	describe( 'searchItemValues', () => {
+		it( 'calls the repo and resolves with the result', async () => {
+			const expectedResult = [ { label: 'potato', id: 'Q666', datatype: 'string' } ];
+			const searchProperties = jest.fn().mockResolvedValue(
+				JSON.parse( JSON.stringify( expectedResult ) ),
+			);
+			const searchItemValues = jest.fn().mockResolvedValue(
+				JSON.parse( JSON.stringify( expectedResult ) ),
+			);
+			const actions = createActions(
+				{ searchProperties, searchItemValues },
+				services.get( 'metricsCollector' ),
+			);
+
+			const searchOptions: SearchOptions = { search: 'potato', limit: 12 };
+			const actualResult = await actions.searchItemValues( {} as any, searchOptions );
+
+			expect( searchItemValues ).toHaveBeenCalledWith(
+				searchOptions.search,
+				searchOptions.limit,
+				searchOptions.offset,
+			);
 			expect( actualResult ).toStrictEqual( expectedResult );
 		} );
 	} );


### PR DESCRIPTION
this method is called by public searchProperties and searchItems methods:
adjust the repository to also allow querying for items
Add an action to use the repository to query for items
Updated searchEntityRepo interfase
Updated tests that use createActions
Added tests specific to the method searchItemValues