### PR TITLE
Add clearFieldErrors mutation to be more purposeful

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -45,10 +45,10 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 			context.dispatch( 'setConditionAsLimitedSupport', payload.conditionIndex );
 		} else {
 			context.commit(
-				'setFieldErrors',
+				'clearFieldErrors',
 				{
-					index: payload.conditionIndex,
-					errors: { propertyError: null },
+					conditionIndex: payload.conditionIndex,
+					errorsToClear: 'property',
 				},
 			);
 		}

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -46,4 +46,18 @@ export default {
 			state.conditionRows[ payload.index ].valueData.valueError = payload.errors.valueError;
 		}
 	},
+	clearFieldErrors(
+		state: RootState,
+		payload: {
+			conditionIndex: number;
+			errorsToClear: 'property'|'value'|'both';
+		},
+	): void {
+		if ( payload.errorsToClear === 'property' || payload.errorsToClear === 'both' ) {
+			state.conditionRows[ payload.conditionIndex ].propertyData.propertyError = null;
+		}
+		if ( payload.errorsToClear === 'value' || payload.errorsToClear === 'both' ) {
+			state.conditionRows[ payload.conditionIndex ].valueData.valueError = null;
+		}
+	},
 };

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -65,11 +65,9 @@ describe( 'actions', () => {
 
 			expect( context.commit ).toHaveBeenCalledTimes( 2 );
 			expect( context.commit ).toHaveBeenCalledWith( 'setProperty', { property, conditionIndex } );
-			expect( context.commit ).toHaveBeenCalledWith( 'setFieldErrors', {
-				index: 0,
-				errors: {
-					propertyError: null,
-				},
+			expect( context.commit ).toHaveBeenCalledWith( 'clearFieldErrors', {
+				conditionIndex: 0,
+				errorsToClear: 'property',
 			} );
 		} );
 

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -97,4 +97,68 @@ describe( 'mutations', () => {
 		expect( state.conditionRows[ 1 ] ).toStrictEqual( expectedNewConditionRow );
 	} );
 
+	describe( 'clearFieldErrors', () => {
+		it( 'clears the property error', () => {
+			const state: RootState = {
+				conditionRows: [ {
+					valueData: { value: '', valueError: { message: 'message-key', type: 'error' } },
+					propertyData: {
+						id: '',
+						label: '',
+						datatype: null,
+						propertyError: { message: 'message-key', type: 'error' },
+					},
+					propertyValueRelationData: { value: PropertyValueRelation.Matching },
+					conditionId: '0.123',
+				} ],
+				errors: [],
+			};
+
+			mutations.clearFieldErrors( state, { conditionIndex: 0, errorsToClear: 'property' } );
+			expect( state.conditionRows[ 0 ].propertyData.propertyError ).toBe( null );
+			expect( state.conditionRows[ 0 ].valueData.valueError ).not.toBe( null );
+		} );
+
+		it( 'clears the value error', () => {
+			const state: RootState = {
+				conditionRows: [ {
+					valueData: { value: '', valueError: { message: 'message-key', type: 'error' } },
+					propertyData: {
+						id: '',
+						label: '',
+						datatype: null,
+						propertyError: { message: 'message-key', type: 'error' },
+					},
+					propertyValueRelationData: { value: PropertyValueRelation.Matching },
+					conditionId: '0.123',
+				} ],
+				errors: [],
+			};
+
+			mutations.clearFieldErrors( state, { conditionIndex: 0, errorsToClear: 'value' } );
+			expect( state.conditionRows[ 0 ].valueData.valueError ).toBe( null );
+			expect( state.conditionRows[ 0 ].propertyData.propertyError ).not.toBe( null );
+		} );
+
+		it( 'clears the both errors', () => {
+			const state: RootState = {
+				conditionRows: [ {
+					valueData: { value: '', valueError: { message: 'message-key', type: 'error' } },
+					propertyData: {
+						id: '',
+						label: '',
+						datatype: null,
+						propertyError: { message: 'message-key', type: 'error' },
+					},
+					propertyValueRelationData: { value: PropertyValueRelation.Matching },
+					conditionId: '0.123',
+				} ],
+				errors: [],
+			};
+
+			mutations.clearFieldErrors( state, { conditionIndex: 0, errorsToClear: 'both' } );
+			expect( state.conditionRows[ 0 ].propertyData.propertyError ).toBe( null );
+			expect( state.conditionRows[ 0 ].valueData.valueError ).toBe( null );
+		} );
+	} );
 } );


### PR DESCRIPTION
This way we don't have to misuse the setFieldErrors mutation for clearing them.