### PR TITLE
Extract EntityLookup and add ItemValueLookup

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -4,6 +4,7 @@
   "query-builder-run-query": "Run query",
   "query-builder-input-value-label": "Value",
   "query-builder-input-value-placeholder": "Enter a value",
+  "query-builder-item-value-lookup-no-match-found": "No match was found",
   "query-builder-property-lookup-label": "Property",
   "query-builder-property-lookup-placeholder": "Enter a property",
   "query-builder-property-lookup-no-match-found": "No match was found",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -9,6 +9,7 @@
 	"query-builder-run-query": "Text on the button that runs the query",
 	"query-builder-input-value-label": "Label of value input field in the form\n{{identical|Value}}",
 	"query-builder-input-value-placeholder": "Placeholder of the value input",
+	"query-builder-item-value-lookup-no-match-found": "Error when no Items match.\n See also {{msg-mw|query-builder-property-lookup-no-match-found}}",
 	"query-builder-property-lookup-label": "Label of the property input\n{{identical|Property}}",
 	"query-builder-property-lookup-placeholder": "Placeholder of the property input",
 	"query-builder-property-lookup-no-match-found": "Error when no properties match",

--- a/src/components/EntityLookup.vue
+++ b/src/components/EntityLookup.vue
@@ -1,0 +1,106 @@
+<template>
+	<Lookup
+		:value="value"
+		@input="$emit( 'input', $event )"
+		:error="error"
+		:menu-items="searchResults"
+		:search-input.sync="search"
+		:placeholder="placeholder"
+		:label="label"
+		v-on:scroll="handleScroll"
+	>
+		<template
+			v-slot:no-results
+		>{{ noMatchFoundMessage }}</template>
+	</Lookup>
+</template>
+
+<script lang="ts">
+import { MenuItem } from '@wmde/wikit-vue-components/dist/components/MenuItem';
+import Vue, { PropType } from 'vue';
+
+import { Lookup } from '@wmde/wikit-vue-components';
+import SearchResult from '@/data-access/SearchResult';
+import SearchOptions from '@/data-access/SearchOptions';
+
+const NUMBER_OF_SEARCH_RESULTS = 12;
+
+export default Vue.extend( {
+	name: 'EntityLookup',
+	components: {
+		Lookup,
+	},
+	data() {
+		return {
+			search: '',
+			searchResults: [] as MenuItem[],
+			topItemIndex: 1,
+		};
+	},
+	methods: {
+		async handleScroll( event: number ): Promise<void> {
+			if ( this.topItemIndex <= event ) {
+				this.topItemIndex += NUMBER_OF_SEARCH_RESULTS;
+
+				const searchOptions: SearchOptions = {
+					search: this.search,
+					offset: this.topItemIndex,
+					limit: NUMBER_OF_SEARCH_RESULTS,
+				};
+
+				this.searchResults = this.searchResults.concat(
+					await this.searchEntities( searchOptions ),
+				);
+			}
+		},
+		async searchEntities( searchOptions: SearchOptions ): Promise<SearchResult[]> {
+			const searchResults = await this.searchForMenuItems( searchOptions );
+			return searchResults.map(
+				( item: MenuItem & SearchResult ) => {
+					item.tag = item.tag && this.$i18n( item.tag );
+					return item;
+				},
+			);
+		},
+	},
+	watch: {
+		async search( newSearchString: string ): Promise<void> {
+			this.topItemIndex = 0;
+			if ( !newSearchString ) {
+				return;
+			}
+			const searchOptions: SearchOptions = {
+				search: newSearchString,
+				limit: NUMBER_OF_SEARCH_RESULTS,
+			};
+			this.searchResults = await this.searchEntities( searchOptions );
+		},
+	},
+	props: {
+		searchForMenuItems: {
+			type: Function as PropType<( searchOptions: SearchOptions ) => Promise<SearchResult[]>>,
+			required: true,
+		},
+		value: {
+			type: Object as PropType<MenuItem>,
+			default: null,
+		},
+		error: {
+			type: Object,
+			default: null,
+		},
+		label: {
+			type: String,
+			required: true,
+		},
+		noMatchFoundMessage: {
+			type: String,
+			required: true,
+		},
+		placeholder: {
+			type: String,
+			default: '',
+		},
+	},
+} );
+</script>

--- a/src/components/ItemValueLookup.vue
+++ b/src/components/ItemValueLookup.vue
@@ -3,10 +3,10 @@
 		:value="value"
 		@input="$emit( 'input', $event )"
 		:error="error ? {message: $i18n(error.message), type: error.type} : null"
-		:searchForMenuItems="searchForProperties"
-		:label="$i18n('query-builder-property-lookup-label')"
-		:placeholder="$i18n('query-builder-property-lookup-placeholder')"
-		:no-match-found-message="$i18n('query-builder-property-lookup-no-match-found')"
+		:searchForMenuItems="searchForItems"
+		:label="$i18n('query-builder-input-value-label')"
+		:placeholder="$i18n('query-builder-input-value-placeholder')"
+		:no-match-found-message="$i18n('query-builder-item-value-lookup-no-match-found')"
 	/>
 </template>
 
@@ -18,23 +18,13 @@ import { MenuItem } from '@wmde/wikit-vue-components/dist/components/MenuItem';
 import Vue, { PropType } from 'vue';
 
 export default Vue.extend( {
-	name: 'PropertyLookup',
+	name: 'ItemValueLookup',
 	components: {
 		EntityLookup,
 	},
 	methods: {
-		setTagForSearchResults( searchResults: SearchResult[] ): SearchResult[] {
-			return searchResults.map(
-				( item: MenuItem & SearchResult ) => {
-					item.tag = item.tag && this.$i18n( item.tag );
-					return item;
-				},
-			);
-		},
-		async searchForProperties( options: SearchOptions ): Promise<SearchResult[]> {
-			return this.setTagForSearchResults(
-				await this.$store.dispatch( 'searchProperties', options ),
-			);
+		searchForItems( options: SearchOptions ): Promise<SearchResult[]> {
+			return this.$store.dispatch( 'searchItemValues', options );
 		},
 	},
 	props: {

--- a/src/components/PropertyLookup.vue
+++ b/src/components/PropertyLookup.vue
@@ -26,7 +26,9 @@ export default Vue.extend( {
 		setTagForSearchResults( searchResults: SearchResult[] ): SearchResult[] {
 			return searchResults.map(
 				( item: MenuItem & SearchResult ) => {
-					item.tag = item.tag && this.$i18n( item.tag );
+					if ( item.tag ) {
+						item.tag = this.$i18n( item.tag );
+					}
 					return item;
 				},
 			);

--- a/tests/unit/components/EntityLookup.spec.ts
+++ b/tests/unit/components/EntityLookup.spec.ts
@@ -13,9 +13,17 @@ localVue.use( i18n, {
 	wikilinks: true,
 } );
 
+const defaultProps = {
+	label: 'some label copy',
+	noMatchFoundMessage: 'some error copy',
+	searchForMenuItems: jest.fn(),
+};
+
 describe( 'EntityLookup.vue', () => {
 	it( 'bubbles input events from the Lookup up', () => {
-		const wrapper = shallowMount( EntityLookup );
+		const wrapper = shallowMount( EntityLookup, {
+			propsData: defaultProps,
+		} );
 		const someEventContent = {};
 
 		wrapper.findComponent( Lookup ).vm.$emit( 'input', someEventContent );
@@ -31,6 +39,7 @@ describe( 'EntityLookup.vue', () => {
 
 		const wrapper = shallowMount( EntityLookup, {
 			propsData: {
+				...defaultProps,
 				value: property,
 			},
 		} );
@@ -44,6 +53,7 @@ describe( 'EntityLookup.vue', () => {
 		const wrapper = shallowMount( EntityLookup, {
 			localVue,
 			propsData: {
+				...defaultProps,
 				searchForMenuItems,
 			},
 		} );
@@ -70,6 +80,7 @@ describe( 'EntityLookup.vue', () => {
 
 		const wrapper = shallowMount( EntityLookup, {
 			propsData: {
+				...defaultProps,
 				error,
 			},
 		} );

--- a/tests/unit/components/EntityLookup.spec.ts
+++ b/tests/unit/components/EntityLookup.spec.ts
@@ -1,0 +1,79 @@
+import EntityLookup from '@/components/EntityLookup.vue';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
+import { Lookup } from '@wmde/wikit-vue-components';
+import i18n from 'vue-banana-i18n';
+import SearchOptions from '@/data-access/SearchOptions';
+
+const localVue = createLocalVue();
+const messages = {};
+
+localVue.use( i18n, {
+	locale: 'en',
+	messages,
+	wikilinks: true,
+} );
+
+describe( 'EntityLookup.vue', () => {
+	it( 'bubbles input events from the Lookup up', () => {
+		const wrapper = shallowMount( EntityLookup );
+		const someEventContent = {};
+
+		wrapper.findComponent( Lookup ).vm.$emit( 'input', someEventContent );
+
+		expect( wrapper.emitted( 'input' )![ 0 ][ 0 ] ).toBe( someEventContent );
+	} );
+
+	it( 'pass value prop down to Lookup', () => {
+		const property = {
+			label: 'some label',
+			description: 'some description',
+		};
+
+		const wrapper = shallowMount( EntityLookup, {
+			propsData: {
+				value: property,
+			},
+		} );
+
+		expect( wrapper.findComponent( Lookup ).props( 'value' ) ).toBe( property );
+	} );
+
+	it( 'uses prop method to search for Entities on new search string', async () => {
+		const searchResults = [ { label: 'abc', description: 'def', id: 'P123' } ];
+		const searchForMenuItems = jest.fn().mockResolvedValue( searchResults );
+		const wrapper = shallowMount( EntityLookup, {
+			localVue,
+			propsData: {
+				searchForMenuItems,
+			},
+		} );
+
+		const searchOptions: SearchOptions = { search: 'postal', limit: 12 };
+
+		wrapper.findComponent( Lookup ).vm.$emit( 'update:search-input', searchOptions.search );
+		await localVue.nextTick();
+
+		expect( searchForMenuItems ).toHaveBeenCalledWith( searchOptions );
+		expect( wrapper.findComponent( Lookup ).props( 'searchInput' ) ).toBe( searchOptions.search );
+
+		// it really needs two ticks ¯\_(ツ)_/¯
+		await localVue.nextTick();
+		await localVue.nextTick();
+		expect( wrapper.findComponent( Lookup ).props( 'menuItems' ) ).toStrictEqual( searchResults );
+	} );
+
+	it( 'passes error prop down to Lookup', () => {
+		const error = {
+			type: 'error',
+			message: 'some description',
+		};
+
+		const wrapper = shallowMount( EntityLookup, {
+			propsData: {
+				error,
+			},
+		} );
+
+		expect( wrapper.findComponent( Lookup ).props( 'error' ) ).toStrictEqual( error );
+	} );
+} );

--- a/tests/unit/components/ItemValueLookup.spec.ts
+++ b/tests/unit/components/ItemValueLookup.spec.ts
@@ -1,4 +1,4 @@
-import PropertyLookup from '@/components/PropertyLookup.vue';
+import ItemValueLookup from '@/components/ItemValueLookup.vue';
 import EntityLookup from '@/components/EntityLookup.vue';
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Vuex from 'vuex';
@@ -7,9 +7,7 @@ import i18n from 'vue-banana-i18n';
 import SearchOptions from '@/data-access/SearchOptions';
 
 const localVue = createLocalVue();
-const messages = { en: {
-	'some-tag-message-key': 'some-tag-copy',
-} };
+const messages = {};
 localVue.use( Vuex );
 
 Vue.use( i18n, {
@@ -18,9 +16,9 @@ Vue.use( i18n, {
 	wikilinks: true,
 } );
 
-describe( 'PropertyLookup.vue', () => {
+describe( 'ItemValueLookup.vue', () => {
 	it( 'bubbles input events from the Lookup up', () => {
-		const wrapper = shallowMount( PropertyLookup );
+		const wrapper = shallowMount( ItemValueLookup );
 		const someEventContent = {};
 
 		wrapper.findComponent( EntityLookup ).vm.$emit( 'input', someEventContent );
@@ -29,38 +27,37 @@ describe( 'PropertyLookup.vue', () => {
 	} );
 
 	it( 'pass value prop down to Lookup', () => {
-		const property = {
+		const item = {
 			label: 'some label',
 			description: 'some description',
 		};
 
-		const wrapper = shallowMount( PropertyLookup, {
+		const wrapper = shallowMount( ItemValueLookup, {
 			propsData: {
-				value: property,
+				value: item,
 			},
 		} );
 
-		expect( wrapper.findComponent( EntityLookup ).props( 'value' ) ).toBe( property );
+		expect( wrapper.findComponent( EntityLookup ).props( 'value' ) ).toBe( item );
 	} );
 
 	it( 'passes search function down and dispatches action when it is called', async () => {
 		const store = new Vuex.Store( {} );
 		const searchResults = [
-			{ label: 'abc', description: 'def', id: 'P123' },
-			{ label: 'date of birth', description: '', id: 'P345', tag: 'some-tag-message-key' },
+			{ label: 'abc', description: 'def', id: 'Q123' },
+			{ label: 'date of birth', description: '', id: 'Q345' },
 		];
 		store.dispatch = jest.fn().mockResolvedValue( searchResults );
 		const expectedSearchResults = JSON.parse( JSON.stringify( searchResults ) );
-		expectedSearchResults[ 1 ].tag = 'some-tag-copy';
-		const wrapper = shallowMount( PropertyLookup, { store, localVue } );
+		const wrapper = shallowMount( ItemValueLookup, { store, localVue } );
 
 		expect( wrapper.findComponent( EntityLookup ).props( 'searchForMenuItems' ) )
-			.toBe( wrapper.vm.searchForProperties );
+			.toBe( wrapper.vm.searchForItems );
 
 		const searchOptions: SearchOptions = { search: 'postal', limit: 12 };
-		const actualSearchOptions = await wrapper.vm.searchForProperties( searchOptions );
+		const actualSearchOptions = await wrapper.vm.searchForItems( searchOptions );
 
-		expect( store.dispatch ).toHaveBeenCalledWith( 'searchProperties', searchOptions );
+		expect( store.dispatch ).toHaveBeenCalledWith( 'searchItemValues', searchOptions );
 		expect( actualSearchOptions ).toStrictEqual( expectedSearchResults );
 	} );
 
@@ -70,7 +67,7 @@ describe( 'PropertyLookup.vue', () => {
 			message: 'some description',
 		};
 
-		const wrapper = shallowMount( PropertyLookup, {
+		const wrapper = shallowMount( ItemValueLookup, {
 			propsData: {
 				error,
 			},

--- a/tests/unit/components/ItemValueLookup.spec.ts
+++ b/tests/unit/components/ItemValueLookup.spec.ts
@@ -52,9 +52,13 @@ describe( 'ItemValueLookup.vue', () => {
 		const wrapper = shallowMount( ItemValueLookup, { store, localVue } );
 
 		expect( wrapper.findComponent( EntityLookup ).props( 'searchForMenuItems' ) )
+			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+			// @ts-ignore
 			.toBe( wrapper.vm.searchForItems );
 
 		const searchOptions: SearchOptions = { search: 'postal', limit: 12 };
+		// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+		// @ts-ignore
 		const actualSearchOptions = await wrapper.vm.searchForItems( searchOptions );
 
 		expect( store.dispatch ).toHaveBeenCalledWith( 'searchItemValues', searchOptions );

--- a/tests/unit/components/PropertyLookup.spec.ts
+++ b/tests/unit/components/PropertyLookup.spec.ts
@@ -55,9 +55,13 @@ describe( 'PropertyLookup.vue', () => {
 		const wrapper = shallowMount( PropertyLookup, { store, localVue } );
 
 		expect( wrapper.findComponent( EntityLookup ).props( 'searchForMenuItems' ) )
+			// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+			// @ts-ignore
 			.toBe( wrapper.vm.searchForProperties );
 
 		const searchOptions: SearchOptions = { search: 'postal', limit: 12 };
+		// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+		// @ts-ignore
 		const actualSearchOptions = await wrapper.vm.searchForProperties( searchOptions );
 
 		expect( store.dispatch ).toHaveBeenCalledWith( 'searchProperties', searchOptions );


### PR DESCRIPTION
ItemValueLookup and PropertyLookup share a lot of logic, yet there are
subtle differences, both in logic and in semantics.

This is passing down a method as a prop. While that might be more
unusual in vuejs than in react, it seems that having the parent maintain
the state only for it to be passed down to the child and having the
child ask for more items on scroll would seem to be much more convoluted
and clumsy.

### TODO:
- [ ] agree on the basic approach
- [x] tests
- [x] messages

Bug: T270256