### PR TITLE
Fixed warning in addcontion unit test

### DIFF
--- a/tests/unit/components/AddCondition.spec.ts
+++ b/tests/unit/components/AddCondition.spec.ts
@@ -2,6 +2,14 @@ import Vue from 'vue';
 import AddCondition from '@/components/AddCondition.vue';
 import { Button } from '@wmde/wikit-vue-components';
 import { shallowMount } from '@vue/test-utils';
+import i18n from 'vue-banana-i18n';
+
+const messages = {};
+Vue.use( i18n, {
+	locale: 'en',
+	messages,
+	wikilinks: true,
+} );
 
 describe( 'AddCondition.vue', () => {
 	it( 'emits an `add-condition` event when Add Condition button is clicked', async () => {


### PR DESCRIPTION
This warning was showing in the tests because the i18n library
was not imported in the tests
[Vue warn]: Failed to resolve directive: i18n (found in <AddCondition>)