### PR TITLE
Extract DeleteConditionButton for better encapsulation

### DIFF
--- a/src/components/DeleteConditionButton.vue
+++ b/src/components/DeleteConditionButton.vue
@@ -1,0 +1,26 @@
+<template>
+	<Button
+		class="delete-condition-button"
+		type="primaryDestructive"
+		@click.native="$emit('click')"
+		:disabled="disabled"
+	> Trash
+	</Button>
+</template>
+
+<script lang="ts">
+import { Button } from '@wmde/wikit-vue-components';
+import Vue from 'vue';
+export default Vue.extend( {
+	name: 'DeleteConditionButton',
+	props: {
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	components: {
+		Button,
+	},
+} );
+</script>

--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -19,20 +19,19 @@
 			:placeholder="$i18n('query-builder-input-value-placeholder')"
 			:disabled="isTextInputDisabled()"
 		/>
-		<Button
+		<DeleteConditionButton
 			class="query-condition__remove"
-			type="primaryDestructive"
-			@click.native="removeCondition"
 			:disabled="!canDelete"
-		> Trash
-		</Button>
+			@click="removeCondition"
+		/>
 	</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { TextInput, Button } from '@wmde/wikit-vue-components';
+import { TextInput } from '@wmde/wikit-vue-components';
 
+import DeleteConditionButton from '@/components/DeleteConditionButton.vue';
 import PropertyLookup from '@/components/PropertyLookup.vue';
 import ValueTypeDropDown from '@/components/ValueTypeDropDown.vue';
 import SearchResult from '@/data-access/SearchResult';
@@ -112,7 +111,7 @@ export default Vue.extend( {
 		TextInput,
 		PropertyLookup,
 		ValueTypeDropDown,
-		Button,
+		DeleteConditionButton,
 	},
 } );
 </script>

--- a/tests/unit/components/QueryCondition.spec.ts
+++ b/tests/unit/components/QueryCondition.spec.ts
@@ -1,3 +1,4 @@
+import DeleteConditionButton from '@/components/DeleteConditionButton.vue';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import { TextInput } from '@wmde/wikit-vue-components';
 import Vuex, { Store } from 'vuex';
@@ -115,7 +116,7 @@ describe( 'QueryCondition.vue', () => {
 			},
 		} );
 
-		wrapper.find( '.query-condition__remove' ).trigger( 'click' );
+		wrapper.findComponent( DeleteConditionButton ).vm.$emit( 'click' );
 
 		await Vue.nextTick();
 


### PR DESCRIPTION
This should contribute towards having all the template in the QueryCondition component be on a single level of abstraction.

Bug: [T271093](https://phabricator.wikimedia.org/T271093)