### PR TITLE
Change flex items alignment to start instead of end

### DIFF
--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -120,7 +120,7 @@ export default Vue.extend( {
 
 	.query-condition {
 		display: flex;
-		align-items: flex-end;
+		align-items: flex-start;
 		margin-block-start: $dimension-layout-medium;
 		padding-block: $dimension-layout-xsmall;
 		padding-inline: $dimension-layout-medium;
@@ -131,6 +131,7 @@ export default Vue.extend( {
 	}
 
 	.query-condition__value-type-dropdown {
+		margin-block-start: $dimension-layout-small;
 		margin-inline-start: $dimension-layout-xsmall;
 	}
 


### PR DESCRIPTION
This way, if there's a validation message in the property input, the
rest of items wouldn't get pushed down.

This change actually makes the value type dropdown to be slightly
misaligned (by 0.25em) that's caused by the internal label in the
dropdown in wikit and needs to be fixed inside separately