### PR TITLE
Make datatype a proper ConditionRow property

### DIFF
--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -10,6 +10,7 @@ export default interface RootState {
 
 export interface ConditionRow {
 	propertyData: PropertyData;
+	datatype: string|null;
 	valueData: {
 		value: string;
 		valueError: Error|null;
@@ -23,6 +24,5 @@ export interface ConditionRow {
 export interface PropertyData {
 	id: string;
 	label: string;
-	datatype: string|null;
 	propertyError: Error|null;
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -48,6 +48,12 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 		payload: { property: { label: string; id: string; datatype: string }; conditionIndex: number } ): void {
 
 		context.commit( 'setProperty', payload );
+		if ( payload.property.datatype ) {
+			context.commit( 'setDatatype', {
+				datatype: payload.property.datatype,
+				conditionIndex: payload.conditionIndex,
+			} );
+		}
 		if ( payload.property && !allowedDatatypes.includes( payload.property.datatype ) ) {
 			context.dispatch( 'setConditionAsLimitedSupport', payload.conditionIndex );
 		} else {
@@ -132,7 +138,7 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 
 		// re-set limited support warning again where applicable
 		context.rootState.conditionRows.forEach( ( conditionRow, index ) => {
-			const datatype = conditionRow.propertyData?.datatype;
+			const datatype = conditionRow.datatype;
 			if ( datatype && !allowedDatatypes.includes( datatype ) ) {
 				context.dispatch( 'setConditionAsLimitedSupport', index );
 			}

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -13,7 +13,7 @@ export default {
 					propertyId: condition.propertyData.id,
 					value: condition.valueData.value,
 					propertyValueRelation: condition.propertyValueRelationData.value,
-					datatype: condition.propertyData.datatype!,
+					datatype: condition.datatype!,
 				};
 			} ),
 			...rootState.useLimit && { limit: rootState.limit },
@@ -37,7 +37,7 @@ export default {
 	},
 	limitedSupport( rootState: RootState ) {
 		return ( conditionIndex: number ): boolean => {
-			const datatype = rootState.conditionRows[ conditionIndex ].propertyData.datatype;
+			const datatype = rootState.conditionRows[ conditionIndex ].datatype;
 			return datatype !== null && !allowedDatatypes.includes( datatype );
 		};
 	},
@@ -54,6 +54,11 @@ export default {
 	propertyValueRelation( rootState: RootState ) {
 		return ( conditionIndex: number ): PropertyValueRelation => {
 			return rootState.conditionRows[ conditionIndex ].propertyValueRelationData.value;
+		};
+	},
+	datatype( rootState: RootState ) {
+		return ( conditionIndex: number ): string | null => {
+			return rootState.conditionRows[ conditionIndex ].datatype;
 		};
 	},
 	limit( rootState: RootState ): ( number | undefined ) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,7 +15,6 @@ export function newEmptyPropertyData( propertyError: Error|null = null ): Proper
 	return {
 		label: '',
 		id: '',
-		datatype: null,
 		propertyError,
 	};
 }
@@ -23,6 +22,7 @@ export function newEmptyPropertyData( propertyError: Error|null = null ): Proper
 export function getFreshConditionRow(): ConditionRow {
 	return {
 		propertyData: newEmptyPropertyData(),
+		datatype: null,
 		valueData: {
 			value: '',
 			valueError: null,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -19,6 +19,9 @@ export default {
 			...payload.property,
 		};
 	},
+	setDatatype( state: RootState, payload: { datatype: string; conditionIndex: number } ): void {
+		state.conditionRows[ payload.conditionIndex ].datatype = payload.datatype;
+	},
 	setPropertyValueRelation( state: RootState,
 		payload: { propertyValueRelation: PropertyValueRelation; conditionIndex: number } ): void {
 		state.conditionRows[ payload.conditionIndex ].propertyValueRelationData.value = payload.propertyValueRelation;

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -63,8 +63,12 @@ describe( 'actions', () => {
 
 			actions.updateProperty( context as any, { property, conditionIndex } );
 
-			expect( context.commit ).toHaveBeenCalledTimes( 2 );
+			expect( context.commit ).toHaveBeenCalledTimes( 3 );
 			expect( context.commit ).toHaveBeenCalledWith( 'setProperty', { property, conditionIndex } );
+			expect( context.commit ).toHaveBeenCalledWith(
+				'setDatatype',
+				{ datatype: 'string', conditionIndex },
+			);
 			expect( context.commit ).toHaveBeenCalledWith( 'clearFieldErrors', {
 				conditionIndex: 0,
 				errorsToClear: 'property',
@@ -89,8 +93,12 @@ describe( 'actions', () => {
 
 			actions.updateProperty( context as any, { property, conditionIndex } );
 
-			expect( context.commit ).toHaveBeenCalledTimes( 1 );
+			expect( context.commit ).toHaveBeenCalledTimes( 2 );
 			expect( context.commit ).toHaveBeenCalledWith( 'setProperty', { property, conditionIndex } );
+			expect( context.commit ).toHaveBeenCalledWith(
+				'setDatatype',
+				{ datatype: 'some unsupported data type', conditionIndex },
+			);
 			expect( context.dispatch ).toHaveBeenCalledWith( 'setConditionAsLimitedSupport', 0 );
 		} );
 	} );
@@ -209,10 +217,10 @@ describe( 'actions', () => {
 				rootState: {
 					conditionRows: [
 						{
+							datatype: null,
 							propertyData: {
 								id: '',
 								label: '',
-								datatype: null,
 								propertyError: null,
 							},
 							valueData: {
@@ -253,10 +261,10 @@ describe( 'actions', () => {
 				rootState: {
 					conditionRows: [
 						{
+							datatype: 'string',
 							propertyData: {
 								id: 'P123',
 								label: 'some string',
-								datatype: 'string',
 								propertyError: null,
 							},
 							valueData: {
@@ -300,10 +308,10 @@ describe( 'actions', () => {
 				rootState: {
 					conditionRows: [
 						{
+							datatype: 'string',
 							propertyData: {
 								id: 'P123',
 								label: 'some string',
-								datatype: 'string',
 								propertyError: null,
 							},
 							valueData: {
@@ -348,10 +356,10 @@ describe( 'actions', () => {
 				rootState: {
 					conditionRows: [
 						{
+							datatype: 'some unsupported data type',
 							propertyData: {
 								id: 'P123',
 								label: 'some string',
-								datatype: 'some unsupported data type',
 								propertyError: null,
 							},
 							valueData: {

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -10,7 +10,8 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					datatype: 'string',
+					propertyData: { id: 'P123', label: 'abc', propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -26,7 +27,8 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: null },
-					propertyData: { id: '', label: '', datatype: null, propertyError: null },
+					datatype: null,
+					propertyData: { id: '', label: '', propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -42,10 +44,10 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: null },
+					datatype: 'I am not supported',
 					propertyData: {
 						id: 'P123',
 						label: 'Lorem Ipsum',
-						datatype: 'I am not supported',
 						propertyError: null,
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -65,7 +67,8 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					datatype: 'string',
+					propertyData: { id: 'P123', label: 'abc', propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -92,7 +95,8 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					datatype: 'string',
+					propertyData: { id: 'P123', label: 'abc', propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -9,7 +9,8 @@ describe( 'mutations', () => {
 		const state: RootState = {
 			conditionRows: [ {
 				valueData: { value: 'foo', valueError: null },
-				propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+				datatype: 'string',
+				propertyData: { id: 'P123', label: 'abc', propertyError: null },
 				propertyValueRelationData: { value: PropertyValueRelation.Matching },
 				conditionId: '0.123',
 			} ],
@@ -31,7 +32,8 @@ describe( 'mutations', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					datatype: 'string',
+					propertyData: { id: 'P123', label: 'abc', propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -50,10 +52,10 @@ describe( 'mutations', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
+					datatype: 'string',
 					propertyData: {
 						id: 'P123',
 						label: 'abc',
-						datatype: 'string',
 						propertyError: preExistingPropertyError,
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -70,7 +72,6 @@ describe( 'mutations', () => {
 				{
 					id: '',
 					label: '',
-					datatype: null,
 					propertyError: preExistingPropertyError,
 				},
 			);
@@ -80,14 +81,16 @@ describe( 'mutations', () => {
 	it( 'addCondition', () => {
 		const expectedNewConditionRow = {
 			valueData: { value: '', valueError: null },
-			propertyData: { id: '', label: '', datatype: null, propertyError: null },
+			datatype: null,
+			propertyData: { id: '', label: '', propertyError: null },
 			propertyValueRelationData: { value: PropertyValueRelation.Matching },
 			conditionId: 'TO BE FILLED WITH THE GENERATED RANDOM VALUE',
 		};
 		const state: RootState = {
 			conditionRows: [ {
 				valueData: { value: 'foo', valueError: null },
-				propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+				datatype: 'string',
+				propertyData: { id: 'P123', label: 'abc', propertyError: null },
 				propertyValueRelationData: { value: PropertyValueRelation.Matching },
 				conditionId: '0.123',
 			} ],
@@ -108,7 +111,8 @@ describe( 'mutations', () => {
 	it( 'removeCondition', () => {
 		const keptRow = {
 			valueData: { value: 'foo', valueError: null },
-			propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+			datatype: 'string',
+			propertyData: { id: 'P123', label: 'abc', propertyError: null },
 			propertyValueRelationData: { value: PropertyValueRelation.Matching },
 			conditionId: '0.123',
 		};
@@ -116,7 +120,8 @@ describe( 'mutations', () => {
 			conditionRows: [ keptRow,
 				{
 					valueData: { value: 'potato', valueError: null },
-					propertyData: { id: 'P666', label: 'Day of the beast', datatype: 'string', propertyError: null },
+					datatype: 'string',
+					propertyData: { id: 'P666', label: 'Day of the beast', propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Regardless },
 					conditionId: '3',
 				},
@@ -138,10 +143,10 @@ describe( 'mutations', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: { message: 'message-key', type: 'error' } },
+					datatype: null,
 					propertyData: {
 						id: '',
 						label: '',
-						datatype: null,
 						propertyError: { message: 'message-key', type: 'error' },
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -161,10 +166,10 @@ describe( 'mutations', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: { message: 'message-key', type: 'error' } },
+					datatype: null,
 					propertyData: {
 						id: '',
 						label: '',
-						datatype: null,
 						propertyError: { message: 'message-key', type: 'error' },
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -184,10 +189,10 @@ describe( 'mutations', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: { message: 'message-key', type: 'error' } },
+					datatype: null,
 					propertyData: {
 						id: '',
 						label: '',
-						datatype: null,
 						propertyError: { message: 'message-key', type: 'error' },
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },


### PR DESCRIPTION
This will allow us to make use of the datatype even when the property is unset and lets us act differently depending on whether the new and the old datatype are the same or not.