### PR TITLE
Explicitly unset property in store 

### DIFF
--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -85,7 +85,11 @@ export default Vue.extend( {
 			get(): SearchResult | null {
 				return this.$store.getters.property( this.conditionIndex );
 			},
-			set( selectedProperty: SearchResult ): void {
+			set( selectedProperty: SearchResult | null ): void {
+				if ( selectedProperty === null ) {
+					this.$store.dispatch( 'unsetProperty', this.conditionIndex );
+					return;
+				}
 				this.$store.dispatch(
 					'updateProperty',
 					{ property: selectedProperty, conditionIndex: this.conditionIndex },

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -44,11 +44,21 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 		payload: { value: string; conditionIndex: number } ): void {
 		context.commit( 'setValue', payload );
 	},
+	unsetProperty( context: ActionContext<RootState, RootState>, conditionIndex: number ): void {
+		context.commit( 'unsetProperty', conditionIndex );
+		context.commit(
+			'clearFieldErrors',
+			{
+				conditionIndex,
+				errorsToClear: 'property',
+			},
+		);
+	},
 	updateProperty( context: ActionContext<RootState, RootState>,
 		payload: { property: { label: string; id: string; datatype: string }; conditionIndex: number } ): void {
 
 		context.commit( 'setProperty', payload );
-		if ( payload.property && !allowedDatatypes.includes( payload.property.datatype ) ) {
+		if ( !allowedDatatypes.includes( payload.property.datatype ) ) {
 			context.dispatch( 'setConditionAsLimitedSupport', payload.conditionIndex );
 		} else {
 			context.commit(

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -9,15 +9,14 @@ export default {
 		state.conditionRows[ payload.conditionIndex ].valueData.value = payload.value;
 	},
 	setProperty( state: RootState, payload: { property: Property | null; conditionIndex: number } ): void {
-		if ( !payload.property ) {
-			state.conditionRows[ payload.conditionIndex ].propertyData.isPropertySet = false;
-			return;
-		}
 		state.conditionRows[ payload.conditionIndex ].propertyData = {
 			...state.conditionRows[ payload.conditionIndex ].propertyData,
 			...payload.property,
 		};
 		state.conditionRows[ payload.conditionIndex ].propertyData.isPropertySet = true;
+	},
+	unsetProperty( state: RootState, conditionIndex: number ): void {
+		state.conditionRows[ conditionIndex ].propertyData.isPropertySet = false;
 	},
 	setPropertyValueRelation( state: RootState,
 		payload: { propertyValueRelation: PropertyValueRelation; conditionIndex: number } ): void {

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -44,6 +44,26 @@ describe( 'actions', () => {
 		} );
 	} );
 
+	it( 'unsetProperty', () => {
+		const context = {
+			commit: jest.fn(),
+		};
+		const conditionIndex = 0;
+		const actions = createActions(
+			services.get( 'searchEntityRepository' ),
+			services.get( 'metricsCollector' ),
+		);
+
+		actions.unsetProperty( context as any, conditionIndex );
+
+		expect( context.commit ).toHaveBeenCalledTimes( 2 );
+		expect( context.commit ).toHaveBeenCalledWith( 'unsetProperty', conditionIndex );
+		expect( context.commit ).toHaveBeenCalledWith( 'clearFieldErrors', {
+			conditionIndex,
+			errorsToClear: 'property',
+		} );
+	} );
+
 	describe( 'updateProperty', () => {
 		it( 'commits the property to the store', () => {
 			const context = {

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -64,40 +64,40 @@ describe( 'mutations', () => {
 
 			expect( state.conditionRows[ conditionIndex ].propertyData ).toStrictEqual( expectedProperty );
 		} );
+	} );
 
-		it( 'clears a property from the state', () => {
-			const preExistingPropertyError = { message: 'some error', type: 'warning' } as const;
-			const state: RootState = {
-				conditionRows: [ {
-					valueData: { value: 'foo', valueError: null },
-					propertyData: {
-						id: 'P123',
-						label: 'abc',
-						datatype: 'string',
-						isPropertySet: true,
-						propertyError: preExistingPropertyError,
-					},
-					propertyValueRelationData: { value: PropertyValueRelation.Matching },
-					conditionId: '0.123',
-				} ],
-				limit: 0,
-				useLimit: false,
-				omitLabels: true,
-				errors: [],
-			};
-
-			mutations.setProperty( state, { property: null, conditionIndex: 0 } );
-
-			expect( state.conditionRows[ 0 ].propertyData ).toStrictEqual(
-				{
+	it( 'unsetProperty', () => {
+		const preExistingPropertyError = { message: 'some error', type: 'warning' } as const;
+		const state: RootState = {
+			conditionRows: [ {
+				valueData: { value: 'foo', valueError: null },
+				propertyData: {
 					id: 'P123',
 					label: 'abc',
 					datatype: 'string',
-					isPropertySet: false,
+					isPropertySet: true,
 					propertyError: preExistingPropertyError,
 				},
-			);
-		} );
+				propertyValueRelationData: { value: PropertyValueRelation.Matching },
+				conditionId: '0.123',
+			} ],
+			limit: 0,
+			useLimit: false,
+			omitLabels: false,
+			errors: [],
+		};
+
+		mutations.unsetProperty( state, 0 );
+
+		expect( state.conditionRows[ 0 ].propertyData ).toStrictEqual(
+			{
+				id: 'P123',
+				label: 'abc',
+				datatype: 'string',
+				isPropertySet: false,
+				propertyError: preExistingPropertyError,
+			},
+		);
 	} );
 
 	it( 'addCondition', () => {


### PR DESCRIPTION
(To be merged into master after #140 and is followed by #141 )

We were already doing that implicitly, because the existing
updateProperty action is already being called with null as the property
without typescript reflecting that.

This now extracts that functionality into its own action and mutation
making the overall flow simpler.

There are no behavioral changes in this commit.