### PR TITLE
Grid layout for condition row

### DIFF
--- a/src/components/PropertyLookup.vue
+++ b/src/components/PropertyLookup.vue
@@ -51,10 +51,3 @@ export default Vue.extend( {
 	},
 } );
 </script>
-<style lang="scss">
-	.query-condition__property-lookup {
-		display: flex;
-		flex-direction: column;
-		flex-wrap: wrap;
-	}
-</style>

--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -1,35 +1,55 @@
 <template>
 	<div class="query-condition">
-		<PropertyLookup
-			class="query-condition__property-lookup"
-			v-model="selectedProperty"
-			:error="propertyError(conditionIndex)"
-		/>
-		<ValueTypeDropDown
-			class="query-condition__value-type-dropdown"
-			v-model="selectedPropertyValueRelation"
-			:disabled="limitedSupport(conditionIndex)"
-		/>
-		<TextInput
-			class="query-condition__value-input"
-			:label="$i18n('query-builder-input-value-label')"
-			ref="value"
-			v-model="textInputValue"
-			:error="valueError"
-			:placeholder="$i18n('query-builder-input-value-placeholder')"
-			:disabled="isTextInputDisabled()"
-		/>
 		<DeleteConditionButton
 			class="query-condition__remove"
 			:disabled="!canDelete"
 			@click="removeCondition"
 		/>
+		<div class="query-condition__toggle-button-group">
+			<Button disabled="true" style="border-right: 1px darkgrey solid;">with</Button>
+			<Button disabled="true">without</Button>
+		</div>
+		<div class="query-condition__input-container">
+			<div>
+				<PropertyLookup
+					class="query-condition__property-lookup"
+					v-model="selectedProperty"
+					:error="propertyError(conditionIndex)"
+				/>
+			</div>
+			<div>
+				<ValueTypeDropDown
+					class="query-condition__value-type-dropdown"
+					v-model="selectedPropertyValueRelation"
+					:disabled="limitedSupport(conditionIndex)"
+				/>
+			</div>
+			<div>
+				<TextInput
+					class="query-condition__value-input"
+					:label="$i18n('query-builder-input-value-label')"
+					ref="value"
+					v-model="textInputValue"
+					:error="valueError"
+					:placeholder="$i18n('query-builder-input-value-placeholder')"
+					:disabled="isTextInputDisabled()"
+				/>
+			</div>
+			<div>
+				<Dropdown
+					class="query-condition__references"
+					label="References"
+					placeholder="with and without references"
+					:disabled="true"
+				/>
+			</div>
+		</div>
 	</div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { TextInput } from '@wmde/wikit-vue-components';
+import { Dropdown, TextInput, Button } from '@wmde/wikit-vue-components';
 
 import DeleteConditionButton from '@/components/DeleteConditionButton.vue';
 import PropertyLookup from '@/components/PropertyLookup.vue';
@@ -112,31 +132,52 @@ export default Vue.extend( {
 		PropertyLookup,
 		ValueTypeDropDown,
 		DeleteConditionButton,
+		Dropdown,
+		Button,
 	},
 } );
 </script>
 
 <style scoped lang="scss">
+$clearWidth: 671px; // Todo: We probably don't want a magic number here
 
-	.query-condition {
-		display: flex;
-		align-items: flex-start;
-		padding-block: $dimension-layout-xsmall;
-		padding-inline: $dimension-layout-medium;
-		background-color: $background-color-base-default;
+.query-condition {
+	padding-block: $dimension-layout-xsmall;
+	padding-inline: $dimension-layout-xsmall;
+	background-color: $background-color-base-default;
 
-		&__remove {
-			margin-inline-start: auto;
+	&__remove {
+		margin-inline-start: $dimension-layout-small;
+		float: inline-end;
+	}
+
+	&__toggle-button-group {
+		white-space: nowrap;
+		float: inline-start;
+		margin-block-start: $dimension-layout-small;
+		margin-inline-end: $dimension-layout-large;
+
+		@media (max-width: $clearWidth) {
+			margin-block-start: 0;
+			margin-inline-end: 0;
 		}
 	}
 
-	.query-condition__value-type-dropdown {
-		margin-block-start: $dimension-layout-small;
-		margin-inline-start: $dimension-layout-xsmall;
-	}
+	&__input-container {
+		display: grid;
+		// Todo: those 17em were chosen by trial to play nice with the 671px $clearWidth - not ideal
+		grid-template-columns: repeat(auto-fit, minmax(17em, 1fr));
+		grid-gap: $dimension-layout-xsmall;
 
-	.query-condition__value-input {
-		margin-inline-start: $dimension-layout-xsmall;
+		@media (max-width: $clearWidth) {
+			padding-block-start: $dimension-layout-small;
+			clear: both;
+		}
 	}
+}
+
+.query-condition__value-type-dropdown {
+	margin-block-start: $dimension-layout-small;
+}
 
 </style>


### PR DESCRIPTION
This adds the placeholders for the planned toggle buttons and references
Dropdown in order to be able to take them into account for the layout.

The magic number for the $clearWidth comes from the magic number for the
intro text. Not ideal, but works for now. Maybe this should be replace
by some em value?

This doesn't work too nicely for very small screens, but it is still
usable.

Bug: [T269470](https://phabricator.wikimedia.org/T270179)