### PR TITLE
Show grey decorator around QueryCondition components

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -10,11 +10,15 @@
 		<div role="form">
 			<h2 class="querybuilder__find-title"
 				v-i18n="{msg: 'query-builder-find-all-items'}" />
-			<QueryCondition
+			<div
+				class="querybuilder__condition-wrapper"
 				v-for="(condition, index) in conditionRows"
-				:condition-index="index"
 				:key="condition.conditionId"
-			/>
+			>
+				<QueryCondition
+					:condition-index="index"
+				/>
+			</div>
 			<AddCondition @add-condition="addCondition" />
 			<div class="querybuilder__run">
 				<Button
@@ -107,6 +111,13 @@ a {
 .querybuilder {
 	padding-block: $dimension-spacing-xlarge;
 	padding-inline: $dimension-spacing-xlarge;
+}
+
+.querybuilder__condition-wrapper {
+	margin-block-start: $dimension-layout-medium;
+	padding-block: $dimension-layout-xsmall;
+	padding-inline: $dimension-layout-xsmall;
+	background-color: $color-base-70; // maybe replace with an alias token?
 }
 
 .querybuilder__heading {

--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -121,9 +121,9 @@ export default Vue.extend( {
 	.query-condition {
 		display: flex;
 		align-items: flex-start;
-		margin-block-start: $dimension-layout-medium;
 		padding-block: $dimension-layout-xsmall;
 		padding-inline: $dimension-layout-medium;
+		background-color: $background-color-base-default;
 
 		&__remove {
 			margin-inline-start: auto;


### PR DESCRIPTION
This is preparatory work for #131 . It wouldn't be strictly necessary yet, but it makes things much less confusing when comparing the QueryBuilder in #131 with the mocks.

This should be merged in master before #131

But: [T269470](https://phabricator.wikimedia.org/T270179)