### PR TITLE
Fix direction detection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-	<div id="app" :lang="lang" dir="textDirection">
+	<div id="app" :lang="lang" :dir="textDirection">
 		<QueryBuilder v-if="isi18nLoaded"/>
 	</div>
 </template>
@@ -51,10 +51,12 @@ export default Vue.extend( {
 				wikilinks: true,
 			} );
 			this.isi18nLoaded = true;
-			this.textDirection = getComputedStyle( document.getElementById( 'app' ) as Element ).direction;
 		};
 
 		fetchi18n();
+	},
+	updated() {
+		this.textDirection = getComputedStyle( document.getElementById( 'directionSample' ) as Element ).direction;
 	},
 	name: 'App',
 	components: {

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="querybuilder" role="main">
-		<h1 class="querybuilder__heading"
-			v-i18n="{msg: 'query-builder-heading'}" />
+		<h1 class="querybuilder__heading"><bdi id="directionSample"
+			v-i18n="{msg: 'query-builder-heading'}" /></h1>
 		<p class="querybuilder__description">
 			Welcome to the test system of the Simple Query Builder. Please note that this is a work in progress,
 			not all features are included, and it can sometimes be broken.


### PR DESCRIPTION
Detecting the direction did not work previously. We need the `<bdi>` to make the browser actually compute the direction before we can read it with getComputedStyle.