### PR TITLE
Make the margin for query wrapper follow the specs

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -117,7 +117,7 @@ a {
 }
 
 .querybuilder__condition-wrapper {
-	margin-block-start: $dimension-layout-medium;
+	margin-block: $dimension-layout-xsmall;
 	padding-block: $dimension-layout-xsmall;
 	padding-inline: $dimension-layout-xsmall;
 	background-color: $color-base-70; // maybe replace with an alias token?


### PR DESCRIPTION
The specs says it should have xsmall margin on top and bottom:
https://www.figma.com/file/hZpaYX0xNNhK0L7kBvN6WK/Query-Builder?node-id=2604%3A29422

Currently, the add condition button is stuck to the wrapper border which
doesn't look nice