### PR TITLE
Add explicit isPropertySet flag to state

### DIFF
--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -26,4 +26,5 @@ export interface PropertyData {
 	label: string;
 	datatype: string|null;
 	propertyError: Error|null;
+	isPropertySet: boolean;
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -110,7 +110,7 @@ export default ( searchEntityRepository: SearchEntityRepository, metricsCollecto
 			context.rootState.conditionRows.map( ( condition: ConditionRow ): FormValues => {
 				// TODO: refactor FormValues to match ConditionRow and remove this mapping
 				return {
-					property: condition.propertyData,
+					property: condition.propertyData.isPropertySet ? condition.propertyData : null,
 					value: condition.valueData.value,
 					propertyValueRelation: condition.propertyValueRelationData.value,
 				};

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -38,6 +38,9 @@ export default {
 	},
 	limitedSupport( rootState: RootState ) {
 		return ( conditionIndex: number ): boolean => {
+			if ( !rootState.conditionRows[ conditionIndex ].propertyData.isPropertySet ) {
+				return false;
+			}
 			const datatype = rootState.conditionRows[ conditionIndex ].propertyData.datatype;
 			return datatype !== null && !allowedDatatypes.includes( datatype );
 		};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,6 +16,7 @@ export function newEmptyPropertyData( propertyError: Error|null = null ): Proper
 		label: '',
 		id: '',
 		datatype: null,
+		isPropertySet: false,
 		propertyError,
 	};
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -2,7 +2,7 @@ import RootState from './RootState';
 import Property from '@/data-model/Property';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import Error from '@/data-model/Error';
-import { getFreshConditionRow, newEmptyPropertyData } from './index';
+import { getFreshConditionRow } from './index';
 
 export default {
 	setValue( state: RootState, payload: { value: string; conditionIndex: number } ): void {
@@ -10,14 +10,14 @@ export default {
 	},
 	setProperty( state: RootState, payload: { property: Property | null; conditionIndex: number } ): void {
 		if ( !payload.property ) {
-			state.conditionRows[ payload.conditionIndex ].propertyData = newEmptyPropertyData(
-				state.conditionRows[ payload.conditionIndex ].propertyData.propertyError,
-			);
+			state.conditionRows[ payload.conditionIndex ].propertyData.isPropertySet = false;
+			return;
 		}
 		state.conditionRows[ payload.conditionIndex ].propertyData = {
 			...state.conditionRows[ payload.conditionIndex ].propertyData,
 			...payload.property,
 		};
+		state.conditionRows[ payload.conditionIndex ].propertyData.isPropertySet = true;
 	},
 	setPropertyValueRelation( state: RootState,
 		payload: { propertyValueRelation: PropertyValueRelation; conditionIndex: number } ): void {

--- a/tests/unit/store/actions.spec.ts
+++ b/tests/unit/store/actions.spec.ts
@@ -263,7 +263,7 @@ describe( 'actions', () => {
 			} );
 		} );
 
-		it( 'adds errors if the form is incomplete', () => {
+		it( 'adds errors if the form is missing a value', () => {
 			const context = {
 				rootState: {
 					conditionRows: [
@@ -272,6 +272,7 @@ describe( 'actions', () => {
 								id: 'P123',
 								label: 'some string',
 								datatype: 'string',
+								isPropertySet: true,
 								propertyError: null,
 							},
 							valueData: {
@@ -310,6 +311,54 @@ describe( 'actions', () => {
 			} );
 		} );
 
+		it( 'adds errors if the form is missing a property', () => {
+			const context = {
+				rootState: {
+					conditionRows: [
+						{
+							propertyData: {
+								id: 'P123',
+								label: 'some string',
+								datatype: 'string',
+								isPropertySet: false,
+								propertyError: null,
+							},
+							valueData: {
+								value: '10777',
+								valueError: null,
+							},
+							propertyValueRelationData: {
+								value: PropertyValueRelation.Matching,
+							},
+						} as ConditionRow,
+					],
+				},
+				commit: jest.fn(),
+			};
+
+			const actions = createActions(
+				services.get( 'searchEntityRepository' ),
+				services.get( 'metricsCollector' ),
+			);
+
+			actions.validateForm( context as any );
+
+			expect( context.commit ).toHaveBeenCalledWith( 'setErrors', [ {
+				message: 'query-builder-result-error-incomplete-form',
+				type: 'error',
+			} ] );
+			expect( context.commit ).toHaveBeenCalledWith( 'setFieldErrors', {
+				errors: {
+					valueError: null,
+					propertyError: {
+						message: 'query-builder-result-error-missing-property',
+						type: 'error',
+					},
+				},
+				index: 0,
+			} );
+		} );
+
 		it( 'removes existing errors', () => {
 			const context = {
 				rootState: {
@@ -319,6 +368,7 @@ describe( 'actions', () => {
 								id: 'P123',
 								label: 'some string',
 								datatype: 'string',
+								isPropertySet: true,
 								propertyError: null,
 							},
 							valueData: {
@@ -367,6 +417,7 @@ describe( 'actions', () => {
 								id: 'P123',
 								label: 'some string',
 								datatype: 'some unsupported data type',
+								isPropertySet: true,
 								propertyError: null,
 							},
 							valueData: {

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -10,7 +10,13 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					propertyData: {
+						id: 'P123',
+						label: 'abc',
+						datatype: 'string',
+						isPropertySet: true,
+						propertyError: null,
+					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -27,7 +33,7 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: '', valueError: null },
-					propertyData: { id: '', label: '', datatype: null, propertyError: null },
+					propertyData: { id: '', label: '', datatype: null, isPropertySet: false, propertyError: null },
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -48,6 +54,7 @@ describe( 'getters', () => {
 						id: 'P123',
 						label: 'Lorem Ipsum',
 						datatype: 'I am not supported',
+						isPropertySet: true,
 						propertyError: null,
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -68,7 +75,13 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					propertyData: {
+						id: 'P123',
+						label: 'abc',
+						datatype: 'string',
+						isPropertySet: true,
+						propertyError: null,
+					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -97,7 +110,13 @@ describe( 'getters', () => {
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					propertyData: {
+						id: 'P123',
+						label: 'abc',
+						datatype: 'string',
+						isPropertySet: true,
+						propertyError: null,
+					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -1,5 +1,5 @@
 import mutations from '@/store/mutations';
-import RootState from '@/store/RootState';
+import RootState, { ConditionRow } from '@/store/RootState';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 
 describe( 'mutations', () => {
@@ -9,7 +9,13 @@ describe( 'mutations', () => {
 		const state: RootState = {
 			conditionRows: [ {
 				valueData: { value: 'foo', valueError: null },
-				propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+				propertyData: {
+					id: 'P123',
+					label: 'abc',
+					datatype: 'string',
+					isPropertySet: true,
+					propertyError: null,
+				},
 				propertyValueRelationData: { value: PropertyValueRelation.Matching },
 				conditionId: '0.123',
 			} ],
@@ -28,11 +34,23 @@ describe( 'mutations', () => {
 
 		it( 'sets a new property in the state', () => {
 			const conditionIndex = 0;
-			const expectedProperty = { id: 'P456', label: 'def', datatype: 'string', propertyError: null };
+			const expectedProperty = {
+				id: 'P456',
+				label: 'def',
+				datatype: 'string',
+				isPropertySet: true,
+				propertyError: null,
+			};
 			const state: RootState = {
 				conditionRows: [ {
 					valueData: { value: 'foo', valueError: null },
-					propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+					propertyData: {
+						id: 'P123',
+						label: 'abc',
+						datatype: 'string',
+						isPropertySet: true,
+						propertyError: null,
+					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
 					conditionId: '0.123',
 				} ],
@@ -56,6 +74,7 @@ describe( 'mutations', () => {
 						id: 'P123',
 						label: 'abc',
 						datatype: 'string',
+						isPropertySet: true,
 						propertyError: preExistingPropertyError,
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -71,9 +90,10 @@ describe( 'mutations', () => {
 
 			expect( state.conditionRows[ 0 ].propertyData ).toStrictEqual(
 				{
-					id: '',
-					label: '',
-					datatype: null,
+					id: 'P123',
+					label: 'abc',
+					datatype: 'string',
+					isPropertySet: false,
 					propertyError: preExistingPropertyError,
 				},
 			);
@@ -83,14 +103,20 @@ describe( 'mutations', () => {
 	it( 'addCondition', () => {
 		const expectedNewConditionRow = {
 			valueData: { value: '', valueError: null },
-			propertyData: { id: '', label: '', datatype: null, propertyError: null },
+			propertyData: { id: '', label: '', datatype: null, isPropertySet: false, propertyError: null },
 			propertyValueRelationData: { value: PropertyValueRelation.Matching },
 			conditionId: 'TO BE FILLED WITH THE GENERATED RANDOM VALUE',
 		};
 		const state: RootState = {
 			conditionRows: [ {
 				valueData: { value: 'foo', valueError: null },
-				propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+				propertyData: {
+					id: 'P123',
+					label: 'abc',
+					datatype: 'string',
+					isPropertySet: true,
+					propertyError: null,
+				},
 				propertyValueRelationData: { value: PropertyValueRelation.Matching },
 				conditionId: '0.123',
 			} ],
@@ -110,9 +136,15 @@ describe( 'mutations', () => {
 	} );
 
 	it( 'removeCondition', () => {
-		const keptRow = {
+		const keptRow: ConditionRow = {
 			valueData: { value: 'foo', valueError: null },
-			propertyData: { id: 'P123', label: 'abc', datatype: 'string', propertyError: null },
+			propertyData: {
+				id: 'P123',
+				label: 'abc',
+				datatype: 'string',
+				isPropertySet: true,
+				propertyError: null,
+			},
 			propertyValueRelationData: { value: PropertyValueRelation.Matching },
 			conditionId: '0.123',
 		};
@@ -120,7 +152,13 @@ describe( 'mutations', () => {
 			conditionRows: [ keptRow,
 				{
 					valueData: { value: 'potato', valueError: null },
-					propertyData: { id: 'P666', label: 'Day of the beast', datatype: 'string', propertyError: null },
+					propertyData: {
+						id: 'P666',
+						label: 'Day of the beast',
+						datatype: 'string',
+						isPropertySet: true,
+						propertyError: null,
+					},
 					propertyValueRelationData: { value: PropertyValueRelation.Regardless },
 					conditionId: '3',
 				},
@@ -143,7 +181,13 @@ describe( 'mutations', () => {
 			conditionRows: [
 				{
 					valueData: { value: 'potato', valueError: null },
-					propertyData: { id: 'P666', label: 'Day of the beast', datatype: 'string', propertyError: null },
+					propertyData: {
+						id: 'P666',
+						label: 'Day of the beast',
+						datatype: 'string',
+						isPropertySet: true,
+						propertyError: null,
+					},
 					propertyValueRelationData: { value: PropertyValueRelation.Regardless },
 					conditionId: '3',
 				},
@@ -171,6 +215,7 @@ describe( 'mutations', () => {
 						id: '',
 						label: '',
 						datatype: null,
+						isPropertySet: false,
 						propertyError: { message: 'message-key', type: 'error' },
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -195,6 +240,7 @@ describe( 'mutations', () => {
 						id: '',
 						label: '',
 						datatype: null,
+						isPropertySet: false,
 						propertyError: { message: 'message-key', type: 'error' },
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },
@@ -219,6 +265,7 @@ describe( 'mutations', () => {
 						id: '',
 						label: '',
 						datatype: null,
+						isPropertySet: false,
 						propertyError: { message: 'message-key', type: 'error' },
 					},
 					propertyValueRelationData: { value: PropertyValueRelation.Matching },


### PR DESCRIPTION
This is needed to allow for marking the property unset while retaining its data. That, in turn, is needed to be able to tell when the datatype changes from changing the property, because in that case the value has to be reset.

This PR replaces #127 
