### PR TITLE
Don't show "NaN" in empty Limit component

### DIFF
--- a/src/components/Limit.vue
+++ b/src/components/Limit.vue
@@ -31,10 +31,14 @@ export default Vue.extend( {
 	computed: {
 		textInputValue: {
 			// TODO: change after deciding how to validate numbers for TextInput
-			get(): ( string | undefined ) {
-				return this.$store.getters.limit?.toString();
+			get(): ( number ) {
+				return this.$store.getters.limit;
 			},
 			set( value: string ): void {
+				if ( isNaN( parseInt( value ) ) ) {
+					this.$store.dispatch( 'setLimit', null );
+					return;
+				}
 				this.$store.dispatch( 'setLimit', parseInt( value ) );
 			},
 		},

--- a/src/store/getters.ts
+++ b/src/store/getters.ts
@@ -60,7 +60,7 @@ export default {
 			return rootState.conditionRows[ conditionIndex ].propertyValueRelationData.value;
 		};
 	},
-	limit( rootState: RootState ): ( number | undefined ) {
+	limit( rootState: RootState ): ( number ) {
 		return rootState.limit;
 	},
 	useLimit( rootState: RootState ): boolean {


### PR DESCRIPTION
This also adjusts some inconsequential parameter and return types.

Bug: [T270712](https://phabricator.wikimedia.org/T270712)