### PR TITLE
Add placeholder to Limit component

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -21,5 +21,7 @@
   "query-builder-value-type-relation-dropdown-regardless-of-value": "regardless of value",
   "query-builder-delete-condition": "Delete condition",
   "query-builder-limit-number-results-description": "Limit the number of results to",
+  "query-builder-limit-number-placeholder": "Enter a number",
+  "query-builder-limit-number-screenreader-label": "Maximum number of results",
   "query-builder-label-opt-out": "Show IDs instead of labels (may prevent timeout)"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -27,5 +27,7 @@
 	"query-builder-value-type-relation-dropdown-regardless-of-value": "Text on dropdown option to have the Query Builder select items that have the given property, regardless of the value it contains. See also {{msg-mw|query-builder-value-type-relation-dropdown-matching}} and {{msg-mw|query-builder-value-type-relation-dropdown-without}}",
 	"query-builder-delete-condition": "Text for screen readers for button that deletes the condition",
 	"query-builder-limit-number-results-description": "Text between checkbox and textfield for limiting the number of results",
+	"query-builder-limit-number-placeholder": "Placeholder message displayed in the number input to specify the maximum number of results. Only displayed in case that input is empty.",
+	"query-builder-limit-number-screenreader-label": "Label for screen-readers only for the number input that limits the number of results. There is a separate checkbox to turn the limit on or off.",
 	"query-builder-label-opt-out": "Label for checkbox to select showing IDs instead of labels in search results. Selecting this option can help prevent timeouts in big queries"
 }

--- a/src/components/Limit.vue
+++ b/src/components/Limit.vue
@@ -14,7 +14,8 @@
 			class="querybuilder__limit-input"
 			v-model="textInputValue"
 			:disabled="!checked"
-			label="Maximum number of results"
+			:label="$i18n('query-builder-limit-number-screenreader-label')"
+			:placeholder="$i18n('query-builder-limit-number-placeholder')"
 		/>
 	</div>
 </template>


### PR DESCRIPTION
This also moves the screen-reader label to the messages to make it translatable.

Bug: [T270712](https://phabricator.wikimedia.org/T270712)