### PR TITLE
Append property id to anyvalue to avoid clashes

### DIFF
--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -89,7 +89,7 @@ export default class QueryObjectBuilder {
 			case ( PropertyValueRelation.Regardless ):
 				return {
 					termType: 'BlankNode',
-					value: 'anyValue',
+					value: 'anyValue' + condition.propertyId,
 				};
 			case ( PropertyValueRelation.Matching ):
 				return this.buildTripleObjectForExplicitValue( condition.datatype, condition.value );

--- a/tests/unit/sparql/buildQuery.spec.ts
+++ b/tests/unit/sparql/buildQuery.spec.ts
@@ -55,14 +55,14 @@ describe( 'buildQuery', () => {
 			},
 		],
 		omitLabels: true,
-		} ) ).toEqual( `SELECT ?item WHERE { ?item (p:${propertyId}/ps:${propertyId}) _:anyValue. }` );
+		} ) ).toEqual( `SELECT ?item WHERE { ?item (p:${propertyId}/ps:${propertyId}) _:anyValue${propertyId}. }` );
 	} );
 
 	it( 'builds a query from multiple conditions, one matching and one regardless', () => {
 		const expectedQuery =
 			`SELECT ?item WHERE {
 			?item (p:P666/ps:P666) "blah".
-			?item (p:P66/ps:P66) _:anyValue.
+			?item (p:P66/ps:P66) _:anyValueP66.
 			}`;
 		const actualQuery = buildQuery( { conditions: [
 			{


### PR DESCRIPTION
When several properties have been chosen with "regardless of value"

Bug: T271903