### PR TITLE
fix: align the icon so that it fits properly into the Button

### DIFF
--- a/src/components/DeleteConditionButton.vue
+++ b/src/components/DeleteConditionButton.vue
@@ -7,7 +7,7 @@
 		:aria-label="$i18n('query-builder-delete-condition')"
 		@click.native="$emit('click')"
 		:disabled="disabled"
-	> <Icon type="trash" size="large" color="inherit" />
+	> <Icon type="trash" size="large" color="inherit" class="delete-condition-button__icon"/>
 	</Button>
 </template>
 
@@ -28,3 +28,9 @@ export default Vue.extend( {
 	},
 } );
 </script>
+
+<style lang="scss">
+	.delete-condition-button__icon {
+		vertical-align: top;
+	}
+</style>


### PR DESCRIPTION
However, for this patch to take affect, the vertical-align rule on the icon in the Wikit Design System has to be removed.

See https://stackoverflow.com/questions/65741031/what-influences-the-actually-rendered-inner-size-of-an-inline-element

Bug: [T268982](https://phabricator.wikimedia.org/T268982)