### PR TITLE
Ensure margin between AddCondition and Limit components

### DIFF
--- a/src/components/AddCondition.vue
+++ b/src/components/AddCondition.vue
@@ -22,6 +22,7 @@ export default Vue.extend( {
 
 <style scoped lang="scss">
 .querybuilder__add-condition {
-	float: inline-end;
+	display: flex;
+	justify-content: flex-end;
 }
 </style>


### PR DESCRIPTION
Floating right is ignoring margins, so we use flex instead so the AddCondition button takes up the space it needs.

Bug: [T270712](https://phabricator.wikimedia.org/T270712#6747720)