### PR TITLE
Fix bug in negation

### DIFF
--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -75,7 +75,8 @@ export default class QueryObjectBuilder {
 			// If it's a negate query only, we need to add "any item" to it otherwise it returns empty result.
 			let isOnlyNegateQuery = true;
 			for ( let i = 0; i < this.queryObject.where?.length; i++ ) {
-				if ( this.queryObject.where[ i ].type !== 'minus' ) {
+				const type = this.queryObject.where[ i ].type;
+				if ( type !== 'minus' && type !== 'service' ) {
 					isOnlyNegateQuery = false;
 					break;
 				}

--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -364,4 +364,119 @@ describe( 'QueryObjectBuilder', () => {
 
 		expect( actual ).toStrictEqual( expected );
 	} );
+
+	it( 'with negate but labels enabled', () => {
+		const prefixes = allNamespaces;
+		const builder = new QueryObjectBuilder();
+		const expected = {
+			queryType: 'SELECT',
+			variables: [
+				{
+					termType: 'Variable',
+					value: 'item',
+				},
+				{
+					termType: 'Variable',
+					value: 'itemLabel',
+				},
+			],
+			where: [
+				{
+					type: 'service',
+					patterns: [
+						{
+							type: 'bgp',
+							triples: [ {
+								subject: {
+									termType: 'NamedNode',
+									value: 'http://www.bigdata.com/rdf#serviceParam',
+								},
+								predicate: {
+									termType: 'NamedNode',
+									value: 'http://wikiba.se/ontology#language',
+								},
+								object: {
+									termType: 'Literal',
+									value: '[AUTO_LANGUAGE]',
+								},
+							} ],
+						},
+					],
+					name: {
+						termType: 'NamedNode',
+						value: 'http://wikiba.se/ontology#label',
+					},
+					silent: false,
+				},
+				{
+					type: 'minus',
+					patterns: [
+						{
+							type: 'bgp',
+							triples: [
+								{
+									subject: {
+										termType: 'Variable',
+										value: 'item',
+									},
+									predicate: { type: 'path',
+										pathType: '/',
+										items: [ {
+											termType: 'NamedNode',
+											value: 'http://www.wikidata.org/prop/P281',
+										},
+										{
+											termType: 'NamedNode',
+											value: 'http://www.wikidata.org/prop/statement/P281',
+										},
+										] },
+									object: {
+										termType: 'Literal',
+										value: 'XXXX',
+									},
+								},
+							],
+						},
+					],
+				},
+				{
+					triples: [
+						{
+							object: {
+								termType: 'BlankNode',
+								value: 'anyValue',
+							},
+							predicate: {
+								termType: 'NamedNode',
+								value: 'http://wikiba.se/ontology#sitelinks',
+							},
+							subject: {
+								termType: 'Variable',
+								value: 'item',
+							},
+						},
+					],
+					type: 'bgp',
+				},
+			],
+			type: 'query',
+			prefixes: prefixes,
+		};
+
+		const actual = builder.buildFromQueryRepresentation( {
+			conditions: [
+				{
+					propertyId: 'P281',
+					value: 'XXXX',
+					datatype: 'string',
+					propertyValueRelation: PropertyValueRelation.Matching,
+					subclasses: false,
+					negate: true,
+				},
+			],
+			omitLabels: false,
+		} );
+
+		expect( actual ).toStrictEqual( expected );
+	} );
 } );


### PR DESCRIPTION
When checking if the "where" condition has only negation or not, if
there is the service for labeling (which is on by default), it thinks
the query has a non-negate value and avoids adding "all items" bit
rendering the query useless.