### PR TITLE
fix: resolve console errors in production and test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
 	transformIgnorePatterns: [
 		'<rootDir>/node_modules/(?!(@wmde/wikit-vue-components)/)',
 	],
+	testEnvironment: '<rootDir>/tests/config/JestCustomEnvironment.js',
 	setupFiles: [ '<rootDir>/.jest/setEnvVars.js' ],
 };

--- a/src/components/Limit.vue
+++ b/src/components/Limit.vue
@@ -29,8 +29,8 @@ export default Vue.extend( {
 	computed: {
 		textInputValue: {
 			// TODO: change after deciding how to validate numbers for TextInput
-			get(): ( number ) {
-				return this.$store.getters.limit;
+			get(): string {
+				return this.$store.getters.limit.toString();
 			},
 			set( value: string ): void {
 				if ( isNaN( parseInt( value ) ) ) {

--- a/src/components/SubclassCheckbox.vue
+++ b/src/components/SubclassCheckbox.vue
@@ -3,9 +3,9 @@
 		<Checkbox
 			class="querybuilder__include-subclasses-checkbox"
 			:id="id"
-			:checked.sync="isChecked"
+			:checked="isChecked"
 			:disabled="disabled"
-			@update:checked="$emit( 'subclass-check', $event.target )"
+			@update:checked="$emit( 'subclass-check', $event )"
 			:label="$i18n('query-builder-include-subclasses' )"
 		/>
 	</div>

--- a/tests/a11y/QueryBuilder.spec.ts
+++ b/tests/a11y/QueryBuilder.spec.ts
@@ -49,6 +49,9 @@ describe( 'QueryBuilder.vue', () => {
 					),
 					negate: jest.fn().mockReturnValue( jest.fn().mockReturnValue( condition.negate ) ),
 					datatype: jest.fn().mockReturnValue( jest.fn().mockReturnValue( condition.datatype ) ),
+					limit: jest.fn().mockReturnValue( 100 ),
+					useLimit: jest.fn().mockReturnValue( true ),
+					omitLabels: jest.fn().mockReturnValue( false ),
 				},
 				actions: {
 					incrementMetric: jest.fn(),

--- a/tests/config/JestCustomEnvironment.js
+++ b/tests/config/JestCustomEnvironment.js
@@ -1,0 +1,24 @@
+const JSDOMEnvironment = require( 'jest-environment-jsdom' );
+
+class JestCustomEnvironment extends JSDOMEnvironment {
+	constructor( config, context ) {
+		super( config, context );
+		Object.assign( context.console, {
+			error( ...args ) {
+				throw new Error(
+					`Unexpected call of console.error() with:\n\n${args.join( ', ' )}`,
+					this.error,
+				);
+			},
+
+			warn( ...args ) {
+				throw new Error(
+					`Unexpected call of console.warn() with:\n\n${args.join( ', ' )}`,
+					this.warn,
+				);
+			},
+		} );
+	}
+}
+
+module.exports = JestCustomEnvironment;

--- a/tests/unit/components/LabelOptout.spec.ts
+++ b/tests/unit/components/LabelOptout.spec.ts
@@ -1,6 +1,7 @@
+import { Checkbox } from '@wmde/wikit-vue-components';
 import Vue from 'vue';
 import LabelOptout from '@/components/LabelOptout.vue';
-import { mount, createLocalVue } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import i18n from 'vue-banana-i18n';
 import Vuex from 'vuex';
 
@@ -17,17 +18,18 @@ localVue.use( Vuex );
 describe( 'LabelOptout.vue', () => {
 	it( 'updates the store when user checks label optout checkbox', async () => {
 		const omitLabels = true;
-		const omitLabelsGetter = () => () => ( omitLabels );
-		const store = new Vuex.Store( { getters: { omitLabelsGetter } } );
+		const omitLabelsGetter = (): boolean => false;
+		const store = new Vuex.Store( {
+			getters: { omitLabels: omitLabelsGetter },
+		} );
 
-		const wrapper = mount( LabelOptout, {
+		const wrapper = shallowMount( LabelOptout, {
 			store,
 			localVue,
 		} );
-
 		store.dispatch = jest.fn();
 
-		await wrapper.find( 'input[type="checkbox"]' ).setChecked();
+		wrapper.findComponent( Checkbox ).vm.$emit( 'update:checked', omitLabels );
 
 		expect( store.dispatch ).toHaveBeenCalledWith( 'setOmitLabels', omitLabels );
 

--- a/tests/unit/components/Limit.spec.ts
+++ b/tests/unit/components/Limit.spec.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Limit from '@/components/Limit.vue';
-import { TextInput } from '@wmde/wikit-vue-components';
+import { Checkbox, TextInput } from '@wmde/wikit-vue-components';
 import Vuex, { Store } from 'vuex';
 import createActions from '@/store/actions';
 import services from '@/ServicesFactory';
@@ -15,7 +15,7 @@ Vue.use( i18n, {
 	wikilinks: true,
 } );
 
-function newStore( getters = {} ): Store<any> {
+function newStore( getters: Record<string, Function> = {} ): Store<any> {
 	return new Vuex.Store( {
 		getters: {
 			property: jest.fn().mockReturnValue( jest.fn() ),
@@ -41,8 +41,8 @@ localVue.use( Vuex );
 describe( 'Limit.vue', () => {
 	it( 'updates the store when user checks useLimit checkbox', async () => {
 		const useLimit = true;
-		const useLimitGetter = () => () => ( useLimit );
-		const store = newStore( useLimitGetter );
+		const useLimitGetter = (): boolean => false;
+		const store = newStore( { useLimit: useLimitGetter, limit: () => 100 } );
 
 		const wrapper = mount( Limit, {
 			store,
@@ -51,7 +51,7 @@ describe( 'Limit.vue', () => {
 
 		store.dispatch = jest.fn();
 
-		await wrapper.find( 'input[type="checkbox"]' ).setChecked();
+		wrapper.findComponent( Checkbox ).vm.$emit( 'update:checked', useLimit );
 
 		expect( store.dispatch ).toHaveBeenCalledWith( 'setUseLimit', useLimit );
 
@@ -59,8 +59,8 @@ describe( 'Limit.vue', () => {
 
 	it( 'updates the store when user changed value in limit field', async () => {
 		const limit = 20;
-		const limitGetter = () => () => ( limit );
-		const store = newStore( limitGetter );
+		const limitGetter = (): number => 10;
+		const store = newStore( { useLimit: () => true, limit: limitGetter } );
 
 		const wrapper = shallowMount( Limit, {
 			store,
@@ -69,7 +69,7 @@ describe( 'Limit.vue', () => {
 
 		store.dispatch = jest.fn();
 
-		await wrapper.findComponent( TextInput ).vm.$emit( 'input', limit.toString() );
+		wrapper.findComponent( TextInput ).vm.$emit( 'input', limit.toString() );
 		// TODO: update when we have a number component
 
 		expect( store.dispatch ).toHaveBeenCalledWith( 'setLimit', limit );

--- a/tests/unit/components/SubclassCheckbox.spec.ts
+++ b/tests/unit/components/SubclassCheckbox.spec.ts
@@ -1,6 +1,7 @@
+import { Checkbox } from '@wmde/wikit-vue-components';
 import Vue from 'vue';
 import SubclassCheckbox from '@/components/SubclassCheckbox.vue';
-import { mount, createLocalVue } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import i18n from 'vue-banana-i18n';
 import Vuex from 'vuex';
 
@@ -20,7 +21,7 @@ describe( 'SubclassCheckbox.vue', () => {
 		const subclassesGetter = () => () => ( subclasses );
 		const store = new Vuex.Store( { getters: { subclassesGetter } } );
 
-		const wrapper = mount( SubclassCheckbox, {
+		const wrapper = shallowMount( SubclassCheckbox, {
 			store,
 			localVue,
 			propsData: {
@@ -31,11 +32,9 @@ describe( 'SubclassCheckbox.vue', () => {
 
 		store.dispatch = jest.fn();
 
-		await wrapper.find( 'input[type="checkbox"]' ).setChecked();
-
-		await Vue.nextTick();
+		wrapper.findComponent( Checkbox ).vm.$emit( 'update:checked', true );
 
 		expect( wrapper.emitted( 'subclass-check' ) ).toBeTruthy();
-
+		expect( wrapper.emitted( 'subclass-check' ) ).toStrictEqual( [ [ true ] ] );
 	} );
 } );


### PR DESCRIPTION
.sync is intended to be used with a data field or maybe a computed
property with a setter. Using it with a prop doesn't make sense as props
are strictly one-way.

The wikit component emits a boolean with its checked event, so we
shouldn't try to access the non-existent "target" field on it.

How the heck has this ever worked?