### PR TITLE
refactor: extract setup and helper methods in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/__tests__/*.{j,t}s?(x)', '**/tests/{unit,a11y}/**/*.spec.{j,t}s?(x)' ],
+			files: [ 'tests/util/*.ts', '**/tests/{unit,a11y}/**/*.spec.{j,t}s?(x)' ],
 			env: {
 				jest: true,
 			},

--- a/src/components/QueryResult.vue
+++ b/src/components/QueryResult.vue
@@ -29,7 +29,7 @@
 <script lang="ts">
 import { Message } from '@wmde/wikit-vue-components';
 import Vue from 'vue';
-import { mapState } from 'vuex';
+import { mapGetters } from 'vuex';
 
 export default Vue.extend( {
 	name: 'QueryResult',
@@ -52,10 +52,8 @@ export default Vue.extend( {
 		},
 	},
 	computed: {
-		...mapState( {
-			property: 'property',
-			textInputValue: 'value',
-			errors: 'errors',
+		...mapGetters( {
+			errors: 'getErrors',
 		} ),
 	},
 	components: {

--- a/tests/a11y/QueryBuilder.spec.ts
+++ b/tests/a11y/QueryBuilder.spec.ts
@@ -1,10 +1,10 @@
-import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import { createLocalVue, mount } from '@vue/test-utils';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import Vuex from 'vuex';
 import Vue from 'vue';
 import i18n from 'vue-banana-i18n';
+import { newStore } from '../util/store';
 
 const localVue = createLocalVue();
 localVue.use( Vuex );
@@ -22,41 +22,8 @@ Vue.use( i18n, {
 
 describe( 'QueryBuilder.vue', () => {
 	it( 'should not have obvious accessibility issues', async () => {
-		const condition = {
-			propertyId: 'P1',
-			value: 'foo',
-			datatype: 'string',
-			propertyValueRelation: PropertyValueRelation.Matching,
-			subclasses: false,
-			negate: false,
-		};
 		const wrapper = mount( QueryBuilder, {
-			store: new Vuex.Store( {
-				state: {
-					errors: [],
-				},
-				getters: {
-					value: jest.fn().mockReturnValue( jest.fn().mockReturnValue( '' ) ),
-					valueError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
-					property: jest.fn().mockReturnValue( jest.fn().mockReturnValue(
-						{ label: 'postal code', id: 'P123' },
-					) ),
-					conditionRows: jest.fn().mockReturnValue( [ condition ] ),
-					propertyError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
-					limitedSupport: jest.fn().mockReturnValue( jest.fn().mockReturnValue( false ) ),
-					propertyValueRelation: jest.fn().mockReturnValue(
-						jest.fn().mockReturnValue( PropertyValueRelation.Matching ),
-					),
-					negate: jest.fn().mockReturnValue( jest.fn().mockReturnValue( condition.negate ) ),
-					datatype: jest.fn().mockReturnValue( jest.fn().mockReturnValue( condition.datatype ) ),
-					limit: jest.fn().mockReturnValue( 100 ),
-					useLimit: jest.fn().mockReturnValue( true ),
-					omitLabels: jest.fn().mockReturnValue( false ),
-				},
-				actions: {
-					incrementMetric: jest.fn(),
-				},
-			} ),
+			store: newStore(),
 			localVue,
 			propsData: {
 				encodedQuery: '',

--- a/tests/unit/components/Limit.spec.ts
+++ b/tests/unit/components/Limit.spec.ts
@@ -1,12 +1,10 @@
 import Vue from 'vue';
 import Limit from '@/components/Limit.vue';
 import { Checkbox, TextInput } from '@wmde/wikit-vue-components';
-import Vuex, { Store } from 'vuex';
-import createActions from '@/store/actions';
-import services from '@/ServicesFactory';
+import Vuex from 'vuex';
 import { shallowMount, createLocalVue, mount } from '@vue/test-utils';
 import i18n from 'vue-banana-i18n';
-import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { newStore } from '../../util/store';
 
 const messages = {};
 Vue.use( i18n, {
@@ -14,26 +12,6 @@ Vue.use( i18n, {
 	messages,
 	wikilinks: true,
 } );
-
-function newStore( getters: Record<string, Function> = {} ): Store<any> {
-	return new Vuex.Store( {
-		getters: {
-			property: jest.fn().mockReturnValue( jest.fn() ),
-			value: jest.fn().mockReturnValue( jest.fn() ),
-			valueError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
-			propertyError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
-			limitedSupport: jest.fn().mockReturnValue( jest.fn().mockReturnValue( false ) ),
-			propertyValueRelation: jest.fn().mockReturnValue(
-				jest.fn().mockReturnValue( PropertyValueRelation.Matching ),
-			),
-			...getters,
-		},
-		actions: createActions(
-			services.get( 'searchEntityRepository' ),
-			services.get( 'metricsCollector' ),
-		),
-	} );
-}
 
 const localVue = createLocalVue();
 localVue.use( Vuex );

--- a/tests/unit/components/QueryBuilder.spec.ts
+++ b/tests/unit/components/QueryBuilder.spec.ts
@@ -1,12 +1,11 @@
 import AddCondition from '@/components/AddCondition.vue';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import QueryBuilder from '@/components/QueryBuilder.vue';
 import Vue from 'vue';
 import i18n from 'vue-banana-i18n';
-import createActions from '@/store/actions';
-import services from '@/ServicesFactory';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { newStore } from '../../util/store';
 const messages = {
 	en: {
 		'query-builder-heading': 'Very fancy query builder title',
@@ -19,19 +18,6 @@ Vue.use( i18n, {
 	messages,
 	wikilinks: true,
 } );
-
-function newStore( getters = {} ): Store<any> {
-	return new Vuex.Store( {
-		getters: {
-			conditionRows: jest.fn().mockReturnValue( [] ),
-			...getters,
-		},
-		actions: createActions(
-			services.get( 'searchEntityRepository' ),
-			services.get( 'metricsCollector' ),
-		),
-	} );
-}
 
 const localVue = createLocalVue();
 localVue.use( Vuex );

--- a/tests/unit/components/QueryCondition.spec.ts
+++ b/tests/unit/components/QueryCondition.spec.ts
@@ -1,16 +1,15 @@
 import DeleteConditionButton from '@/components/DeleteConditionButton.vue';
 import ValueInput from '@/components/ValueInput.vue';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import PropertyLookup from '@/components/PropertyLookup.vue';
 import Vue from 'vue';
 import i18n from 'vue-banana-i18n';
-import createActions from '@/store/actions';
-import services from '@/ServicesFactory';
 import QueryCondition from '@/components/QueryCondition.vue';
 import NegationToggle from '@/components/NegationToggle.vue';
 import SubclassCheckbox from '@/components/SubclassCheckbox.vue';
+import { newStore } from '../../util/store';
 const messages = {};
 
 Vue.use( i18n, {
@@ -18,30 +17,6 @@ Vue.use( i18n, {
 	messages,
 	wikilinks: true,
 } );
-
-function newStore( getters = {} ): Store<any> {
-	return new Vuex.Store( {
-		getters: {
-			property: jest.fn().mockReturnValue( jest.fn() ),
-			datatype: jest.fn().mockReturnValue( jest.fn() ),
-			value: jest.fn().mockReturnValue( jest.fn() ),
-			negate: jest.fn().mockReturnValue( jest.fn() ),
-			valueError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
-			propertyError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
-			conditionRows: jest.fn().mockReturnValue( jest.fn().mockReturnValue( Array ) ),
-			limitedSupport: jest.fn().mockReturnValue( jest.fn().mockReturnValue( false ) ),
-			subclasses: jest.fn().mockReturnValue( jest.fn().mockReturnValue( false ) ),
-			propertyValueRelation: jest.fn().mockReturnValue(
-				jest.fn().mockReturnValue( PropertyValueRelation.Matching ),
-			),
-			...getters,
-		},
-		actions: createActions(
-			services.get( 'searchEntityRepository' ),
-			services.get( 'metricsCollector' ),
-		),
-	} );
-}
 
 const localVue = createLocalVue();
 localVue.use( Vuex );
@@ -70,8 +45,7 @@ describe( 'QueryCondition.vue', () => {
 
 	it( 'updates the store property when the user changes it in the lookup', async () => {
 		const property = { label: 'postal code', id: 'P123' };
-		const propertyGetter = () => () => ( property );
-		const store = newStore( propertyGetter );
+		const store = newStore();
 		const conditionIndex = 0;
 		store.dispatch = jest.fn();
 		const wrapper = shallowMount( QueryCondition, {
@@ -108,9 +82,8 @@ describe( 'QueryCondition.vue', () => {
 
 	it( 'set subclasses to true when property type is wikibase-item', async () => {
 
-		const property = { label: 'postal code', id: 'P123', datatype: 'wikibase-item' };
-		const propertyGetter = () => () => ( property );
-		const store = newStore( propertyGetter );
+		const property = { label: 'postal code', id: 'P31', datatype: 'wikibase-item' };
+		const store = newStore();
 		const conditionIndex = 0;
 		store.dispatch = jest.fn();
 		const wrapper = shallowMount( QueryCondition, {
@@ -129,8 +102,7 @@ describe( 'QueryCondition.vue', () => {
 	it( 'set subclasses to false when property type is string', async () => {
 
 		const property = { label: 'postal code', id: 'P123', datatype: 'string' };
-		const propertyGetter = () => () => ( property );
-		const store = newStore( propertyGetter );
+		const store = newStore();
 		const conditionIndex = 0;
 		store.dispatch = jest.fn();
 		const wrapper = shallowMount( QueryCondition, {

--- a/tests/unit/components/QueryResult.spec.ts
+++ b/tests/unit/components/QueryResult.spec.ts
@@ -4,12 +4,11 @@ import QueryResult from '@/components/QueryResult.vue';
 import Vue from 'vue';
 import i18n from 'vue-banana-i18n';
 
-function newStore( state = {} ): Store<any> {
+function newStore( getters = {} ): Store<any> {
 	return new Vuex.Store( {
-		state: {
-			property: 'potato',
-			errors: [],
-			...state,
+		getters: {
+			getErrors: () => jest.fn().mockReturnValue( [] ),
+			...getters,
 		},
 	} );
 }
@@ -36,7 +35,6 @@ describe( 'QueryResult.vue', () => {
 			propsData: {
 				encodedQuery: '',
 				iframeRenderKey: 0,
-				errors: [],
 			},
 		} );
 		expect( wrapper.find( '.querybuilder__result__description' ).text() ).toBe( 'Result placeholder' );
@@ -46,7 +44,7 @@ describe( 'QueryResult.vue', () => {
 	it( 'Show errors', () => {
 		const store = newStore(
 			{
-				errors: [
+				getErrors: () => [
 					{
 						message: 'Something happened',
 						type: 'notice',

--- a/tests/unit/components/QueryResult.spec.ts
+++ b/tests/unit/components/QueryResult.spec.ts
@@ -1,17 +1,9 @@
-import Vuex, { Store } from 'vuex';
+import Vuex from 'vuex';
 import { shallowMount, createLocalVue, mount } from '@vue/test-utils';
 import QueryResult from '@/components/QueryResult.vue';
 import Vue from 'vue';
 import i18n from 'vue-banana-i18n';
-
-function newStore( getters = {} ): Store<any> {
-	return new Vuex.Store( {
-		getters: {
-			getErrors: () => jest.fn().mockReturnValue( [] ),
-			...getters,
-		},
-	} );
-}
+import { newStore } from '../../util/store';
 
 const localVue = createLocalVue();
 const messages = {

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -2,32 +2,9 @@ import RootState from '@/store/RootState';
 import getters from '@/store/getters';
 import QueryRepresentation from '@/sparql/QueryRepresentation';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { getFreshRootState } from '../../util/store';
 
 describe( 'getters', () => {
-	function getFreshRootState(): RootState {
-		const simpleRootState: RootState = {
-			conditionRows: [ {
-				valueData: { value: 'foo', valueError: null },
-				propertyData: {
-					id: 'P123',
-					label: 'abc',
-					datatype: 'string',
-					isPropertySet: true,
-					propertyError: null,
-				},
-				propertyValueRelationData: { value: PropertyValueRelation.Matching },
-				conditionId: '0.123',
-				subclasses: false,
-				negate: false,
-			} ],
-			limit: 0,
-			useLimit: false,
-			omitLabels: true,
-			errors: [],
-		};
-		return simpleRootState;
-	}
-
 	describe( 'limitedSupport', () => {
 		it( 'returns false if the datatype is supported', () => {
 			const state: RootState = getFreshRootState();

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -1,31 +1,9 @@
 import mutations from '@/store/mutations';
 import RootState, { ConditionRow } from '@/store/RootState';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { getFreshRootState } from '../../util/store';
 
 describe( 'mutations', () => {
-	function getFreshRootState(): RootState {
-		const simpleRootState = {
-			conditionRows: [ {
-				valueData: { value: 'foo', valueError: null },
-				propertyData: {
-					id: 'P123',
-					label: 'abc',
-					datatype: 'string',
-					isPropertySet: true,
-					propertyError: null,
-				},
-				propertyValueRelationData: { value: PropertyValueRelation.Matching },
-				conditionId: '0.123',
-				subclasses: false,
-				negate: false,
-			} ],
-			limit: 0,
-			useLimit: false,
-			omitLabels: true,
-			errors: [],
-		};
-		return simpleRootState;
-	}
 	it( 'setValue', () => {
 		const expectedValue = 'whatever';
 		const state: RootState = getFreshRootState();

--- a/tests/util/store.ts
+++ b/tests/util/store.ts
@@ -1,5 +1,6 @@
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import RootState from '@/store/RootState';
+import Vuex, { Store } from 'vuex';
 
 export function getFreshRootState(): RootState {
 	return {
@@ -22,4 +23,31 @@ export function getFreshRootState(): RootState {
 		omitLabels: true,
 		errors: [],
 	};
+}
+
+export function newStore( getters: Record<string, Function> = {} ): Store<any> {
+	return new Vuex.Store( {
+		getters: {
+			conditionRows: jest.fn().mockReturnValue( jest.fn().mockReturnValue( [] ) ),
+			property: jest.fn().mockReturnValue( jest.fn() ),
+			propertyError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
+			datatype: jest.fn().mockReturnValue( jest.fn() ),
+			value: jest.fn().mockReturnValue( jest.fn() ),
+			valueError: jest.fn().mockReturnValue( jest.fn().mockReturnValue( null ) ),
+			negate: jest.fn().mockReturnValue( jest.fn() ),
+			limitedSupport: jest.fn().mockReturnValue( jest.fn().mockReturnValue( false ) ),
+			subclasses: jest.fn().mockReturnValue( jest.fn().mockReturnValue( false ) ),
+			propertyValueRelation: jest.fn().mockReturnValue(
+				jest.fn().mockReturnValue( PropertyValueRelation.Matching ),
+			),
+			limit: jest.fn().mockReturnValue( 100 ),
+			useLimit: jest.fn().mockReturnValue( true ),
+			omitLabels: jest.fn().mockReturnValue( false ),
+			getErrors: jest.fn().mockReturnValue( [] ),
+			...getters,
+		},
+		actions: {
+			incrementMetric: jest.fn(),
+		},
+	} );
 }

--- a/tests/util/store.ts
+++ b/tests/util/store.ts
@@ -1,0 +1,25 @@
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import RootState from '@/store/RootState';
+
+export function getFreshRootState(): RootState {
+	return {
+		conditionRows: [ {
+			valueData: { value: 'foo', valueError: null },
+			propertyData: {
+				id: 'P123',
+				label: 'abc',
+				datatype: 'string',
+				isPropertySet: true,
+				propertyError: null,
+			},
+			propertyValueRelationData: { value: PropertyValueRelation.Matching },
+			conditionId: '0.123',
+			subclasses: false,
+			negate: false,
+		} ],
+		limit: 0,
+		useLimit: false,
+		omitLabels: true,
+		errors: [],
+	};
+}


### PR DESCRIPTION
This is inspired by the pattern seen in bridge: https://github.com/wikimedia/Wikibase/blob/master/client/data-bridge/tests/util/store.ts