### PR TITLE
refactor: listen for event on ToggleButtonGroup not ToggleButtons

### DIFF
--- a/src/components/NegationToggle.vue
+++ b/src/components/NegationToggle.vue
@@ -1,17 +1,20 @@
 <template>
 	<ToggleButtonGroup
 		:value="value"
+		@input="$emit('input', $event)"
 		class="negationToggle"
 	>
 		<template v-slot:default>
 			<ToggleButton
 				value="with"
-				@click.native="$emit('input', 'with')"
-			>{{ $i18n( 'query-builder-negation-option-label-with' ) }}</ToggleButton>
+			>
+				{{ $i18n( 'query-builder-negation-option-label-with' ) }}
+			</ToggleButton>
 			<ToggleButton
 				value="without"
-				@click.native="$emit('input', 'without')"
-			>{{ $i18n( 'query-builder-negation-option-label-without' ) }}</ToggleButton>
+			>
+				{{ $i18n( 'query-builder-negation-option-label-without' ) }}
+			</ToggleButton>
 		</template>
 	</ToggleButtonGroup>
 </template>
@@ -31,9 +34,3 @@ export default Vue.extend( {
 	},
 } );
 </script>
-
-<style scoped lang="scss">
-	.negationToggle {
-		white-space: nowrap;
-	}
-</style>

--- a/tests/unit/components/NegationToggle.spec.ts
+++ b/tests/unit/components/NegationToggle.spec.ts
@@ -1,6 +1,42 @@
+import NegationToggle from '@/components/NegationToggle.vue';
+import { shallowMount } from '@vue/test-utils';
+import { ToggleButton, ToggleButtonGroup } from '@wmde/wikit-vue-components';
+import Vue from 'vue';
+import i18n from 'vue-banana-i18n';
+
+const messages = {};
+Vue.use( i18n, {
+	locale: 'en',
+	messages,
+	wikilinks: true,
+} );
+
 describe( 'NegationToggle', () => {
-	// TODO: Write those tests when using the upcoming ButtonToggle component -> T271788
-	it.todo( 'passes the value down to the ButtonToggle' );
-	it.todo( 'passes down options for negation to the Button Toggle' );
-	it.todo( 'bubbles up the input event from the ButtonToggle' );
+	it( 'passes the value down to the ToggleButtonGroup', () => {
+		const value = 'without';
+		const wrapper = shallowMount( NegationToggle, {
+			propsData: {
+				value,
+			},
+		} );
+
+		expect( wrapper.findComponent( ToggleButtonGroup ).props() ).toStrictEqual( { value } );
+	} );
+
+	it( 'creates a ToggleButton for each option', () => {
+		const wrapper = shallowMount( NegationToggle );
+
+		const toggleButtons = wrapper.findAllComponents( ToggleButton );
+		expect( toggleButtons.length ).toBe( 2 );
+		expect( toggleButtons.at( 0 ).props( 'value' ) ).toBe( 'with' );
+		expect( toggleButtons.at( 1 ).props( 'value' ) ).toBe( 'without' );
+	} );
+
+	it( 'bubbles up the input event from the ToggleButtonGroup', () => {
+		const wrapper = shallowMount( NegationToggle );
+
+		wrapper.findComponent( ToggleButtonGroup ).vm.$emit( 'input', 'without' );
+
+		expect( wrapper.emitted( 'input' ) ).toStrictEqual( [ [ 'without' ] ] );
+	} );
 } );


### PR DESCRIPTION
Listening on the `ToggleButtonGroup` is the way it is intended to be used as can be seen in the Wikit Storybook. Listening on the buttons creates a lot of redundancy if there are many buttons.

Also this PR adds the tests for this component.