### PR TITLE
ci: add info about previous commits to Sonar

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up node
       uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
By default actions/checkout@v2 only fetches a single commit. It would be nice to have the entire commit history available in Sonar.

Also, it makes that small warning go away in the Sonar interface, which is also nice.