### PR TITLE
browser tests: don't hardcode the API URL

### DIFF
--- a/.github/workflows/test-and-netlify.yml
+++ b/.github/workflows/test-and-netlify.yml
@@ -37,3 +37,5 @@ jobs:
         browser: chrome
         headless: true
         config: pageLoadTimeout=60000,baseUrl=${{ env.DEPLOY_URL }}
+      env:
+        CYPRESS_API_URL: 'https://www.wikidata.org/w/api.php'

--- a/cypress/integration/basic-query.spec.js
+++ b/cypress/integration/basic-query.spec.js
@@ -1,6 +1,9 @@
+const API_URL = Cypress.env( 'API_URL' )
+	.replace( /(^')|('$)/g, '' ); // for some reason Cypress keeps quotes around env vars coming from docker through `.env`
+
 function wikibaseApiRequest( query ) {
 	return {
-		url: 'https://www.wikidata.org/w/api.php',
+		url: API_URL,
 		query,
 	};
 }

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -11,3 +11,4 @@ services:
         command: "--browser chrome --headless"
         environment:
             - CYPRESS_BASE_URL=http://dev:${PORT}
+            - CYPRESS_API_URL=${VUE_APP_WIKIBASE_API_URL}


### PR DESCRIPTION
Since the Wikibase API URL is passed in via environment variable to the query builder, it should also be configurable for the browser tests. Cypress requires the `CYPRESS_` prefix ([docs](https://docs.cypress.io/guides/guides/environment-variables.html#Option-3-CYPRESS)) which meant that the existing `VUE_APP_WIKIBASE_API_URL` couldn't be reused. It also does some strange things with quoted variables.