### PR TITLE
Group reference patterns into one

### DIFF
--- a/src/sparql/PatternBuilder.ts
+++ b/src/sparql/PatternBuilder.ts
@@ -74,9 +74,10 @@ export default class PatternBuilder {
 		} else {
 			if ( condition.referenceRelation === ReferenceRelation.With ||
                 condition.referenceRelation === ReferenceRelation.Without ) {
-				patterns.push( bgpReference );
-				patterns.push( bgp );
-				patterns.push( referenceFilter );
+				patterns.push( {
+					type: 'group',
+					patterns: [ bgpReference, bgp, referenceFilter ],
+				} );
 			} else {
 				patterns.push( bgp );
 			}

--- a/tests/unit/sparql/buildQuery.spec.ts
+++ b/tests/unit/sparql/buildQuery.spec.ts
@@ -101,10 +101,10 @@ describe( 'buildQuery', () => {
 			omitLabels: true,
 		} );
 		const expectedQuery = `SELECT DISTINCT ?item WHERE {
-			?item p:P666 ?statement0.
+			{ ?item p:P666 ?statement0.
 			?statement0 (ps:${propertyId}) "${value}". 
 			FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. 
-			}) }`;
+			}) } }`;
 		expect( actualQuery.replace( /\s+/g, ' ' ) ).toEqual( expectedQuery.replace( /\s+/g, ' ' ) );
 	} );
 
@@ -121,10 +121,10 @@ describe( 'buildQuery', () => {
 			omitLabels: true,
 		} );
 		const expectedQuery = `SELECT DISTINCT ?item WHERE {
-			?item p:P666 ?statement0.
+			{ ?item p:P666 ?statement0.
 			?statement0 (ps:${propertyId}) "${value}". 
 			FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. 
-			}) }`;
+			}) } }`;
 		expect( actualQuery.replace( /\s+/g, ' ' ) ).toEqual( expectedQuery.replace( /\s+/g, ' ' ) );
 	} );
 


### PR DESCRIPTION
This way, the resulting query when there is a union and reference filter
wouldn't be wrong anymore.

Bug: T274101