### PR TITLE
fix: debounce searching for options on typing

### DIFF
--- a/src/data-access/FetchSearchEntityRepository.ts
+++ b/src/data-access/FetchSearchEntityRepository.ts
@@ -1,4 +1,3 @@
-import debounce from 'lodash/debounce';
 import SearchEntityRepository from '@/data-access/SearchEntityRepository';
 import SearchResult from '@/data-access/SearchResult';
 import TechnicalProblem from '@/data-access/errors/TechnicalProblem';
@@ -40,12 +39,8 @@ export default class FetchSearchEntityRepository implements SearchEntityReposito
 			url.searchParams.set( key, params[ key ] );
 		}
 		let response: Response;
-		const debouncedFetch = debounce( fetch, 300, {
-			leading: true,
-			trailing: true,
-		} );
 		try {
-			response = await debouncedFetch( url.toString() ) as Response;
+			response = await fetch( url.toString() );
 		} catch ( e ) {
 			throw new TechnicalProblem( 'Network error' );
 		}

--- a/tests/unit/components/EntityLookup.spec.ts
+++ b/tests/unit/components/EntityLookup.spec.ts
@@ -5,6 +5,8 @@ import Vue from 'vue';
 import i18n from 'vue-banana-i18n';
 import SearchOptions from '@/data-access/SearchOptions';
 
+jest.mock( 'lodash/debounce', () => jest.fn( ( fn ) => fn ) );
+
 const localVue = createLocalVue();
 const messages = { en: {
 	'some-error-message-key': 'some-error-copy',
@@ -75,6 +77,34 @@ describe( 'EntityLookup.vue', () => {
 		await localVue.nextTick();
 		await localVue.nextTick();
 		expect( wrapper.findComponent( Lookup ).props( 'menuItems' ) ).toStrictEqual( searchResults );
+	} );
+
+	it( 'clears the search results on the search string being emptied', async () => {
+		const searchForMenuItems = jest.fn();
+		const wrapper = shallowMount( EntityLookup, {
+			localVue,
+			propsData: {
+				...defaultProps,
+				searchForMenuItems,
+			},
+			data() {
+				return {
+					searchResults: [
+						{ label: 'abc', description: 'def', id: 'P123' },
+						{ label: 'ghi', description: 'def', id: 'P1234' },
+						{ label: 'jkl', description: 'def', id: 'P12345' },
+					],
+					search: 'def',
+				};
+			},
+		} );
+
+		wrapper.findComponent( Lookup ).vm.$emit( 'update:search-input', '' );
+		await localVue.nextTick();
+
+		expect( searchForMenuItems ).not.toHaveBeenCalled();
+		expect( wrapper.findComponent( Lookup ).props( 'searchInput' ) ).toBe( '' );
+		expect( wrapper.findComponent( Lookup ).props( 'menuItems' ) ).toStrictEqual( [] );
 	} );
 
 	it( 'passes error prop down to Lookup', () => {


### PR DESCRIPTION
The debounce in the repository wasn't working as it was recreated on every call.

Unfortunately, lodash.debounce does not properly work with methods that actually return something as it seemingly always returns undefined on first invocation.

Therefore, the debounce is moved to the EntityLookup, and the update to the state happens inside the debounced method.

Bug: T273868