### PR TITLE
refactor: adjust obsolete names and types in QueryCondition

### DIFF
--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -26,14 +26,14 @@
 			<div>
 				<ValueInput
 					class="query-condition__value-input"
-					:disabled="isTextInputDisabled()"
-					v-model="textInputValue"
+					:disabled="isValueInputDisabled()"
+					v-model="conditionValue"
 					:error="valueError"
 					:datatype="datatype"
 				/>
 				<SubclassCheckbox
 					v-if="subclassCheckboxVisible"
-					:disabled="isTextInputDisabled()"
+					:disabled="isValueInputDisabled()"
 					@subclass-check="setSubclasses"
 					:isChecked="subclasses(conditionIndex)" />
 			</div>
@@ -48,6 +48,7 @@
 </template>
 
 <script lang="ts">
+import { Value } from '@/store/RootState';
 import Vue from 'vue';
 
 import ValueInput from '@/components/ValueInput.vue';
@@ -77,7 +78,7 @@ export default Vue.extend( {
 		},
 	},
 	methods: {
-		isTextInputDisabled(): boolean {
+		isValueInputDisabled(): boolean {
 			return this.selectedPropertyValueRelation === PropertyValueRelation.Regardless;
 		},
 		removeCondition(): void {
@@ -118,7 +119,7 @@ export default Vue.extend( {
 			},
 			set( selectedPropertyValueRelation: PropertyValueRelation ): void {
 				if ( selectedPropertyValueRelation === PropertyValueRelation.Regardless ) {
-					this.textInputValue = '';
+					this.conditionValue = null;
 				}
 				this.$store.dispatch(
 					'updatePropertyValueRelation',
@@ -137,9 +138,11 @@ export default Vue.extend( {
 				);
 			},
 		},
-		textInputValue: {
-			get(): string { return this.$store.getters.value( this.conditionIndex ); },
-			set( value: string ): void {
+		conditionValue: {
+			get(): Value {
+				return this.$store.getters.value( this.conditionIndex );
+			},
+			set( value: Value ): void {
 				this.$store.dispatch( 'updateValue', { value, conditionIndex: this.conditionIndex } );
 			},
 		},

--- a/tests/unit/components/QueryCondition.spec.ts
+++ b/tests/unit/components/QueryCondition.spec.ts
@@ -1,5 +1,6 @@
 import DeleteConditionButton from '@/components/DeleteConditionButton.vue';
 import ValueInput from '@/components/ValueInput.vue';
+import ValueTypeDropDown from '@/components/ValueTypeDropDown.vue';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import Vuex from 'vuex';
 import { shallowMount, createLocalVue } from '@vue/test-utils';
@@ -207,5 +208,25 @@ describe( 'QueryCondition.vue', () => {
 		await Vue.nextTick();
 		expect( wrapper.findComponent( SubclassCheckbox ).props( 'disabled' ) ).toBeTruthy();
 		expect( wrapper.findComponent( ValueInput ).props( 'disabled' ) ).toBeTruthy();
+	} );
+
+	it( 'sets the value to null if the user switches the relation to "Regardless of value', () => {
+		const store = newStore();
+		store.dispatch = jest.fn();
+		const wrapper = shallowMount( QueryCondition, {
+			store,
+			localVue,
+			propsData: {
+				'condition-index': 0,
+			},
+		} );
+
+		wrapper.findComponent( ValueTypeDropDown ).vm.$emit( 'input', PropertyValueRelation.Regardless );
+
+		expect( store.dispatch ).toHaveBeenCalledWith( 'updateValue', { value: null, conditionIndex: 0 } );
+		expect( store.dispatch ).toHaveBeenCalledWith(
+			'updatePropertyValueRelation',
+			{ propertyValueRelation: PropertyValueRelation.Regardless, conditionIndex: 0 },
+		);
 	} );
 } );


### PR DESCRIPTION
Since we are no longer only using a TextInput as the input for the
value, the names should also be more general.

Also, this might fix the error message in the console when switching the
relation to "regardless of value".