### PR TITLE
fix: show subclass checkbox for item properties when reconstructing

### DIFF
--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -32,7 +32,7 @@
 					:datatype="datatype"
 				/>
 				<SubclassCheckbox
-					v-if="subclassCheckboxVisible"
+					v-if="isSubclassCheckboxVisible"
 					:disabled="isValueInputDisabled()"
 					@subclass-check="setSubclasses"
 					:isChecked="subclasses(conditionIndex)" />
@@ -66,11 +66,6 @@ import ReferenceRelation from '@/data-model/ReferenceRelation';
 
 export default Vue.extend( {
 	name: 'QueryCondition',
-	data() {
-		return {
-			subclassCheckboxVisible: false,
-		};
-	},
 	props: {
 		conditionIndex: {
 			type: Number,
@@ -102,16 +97,17 @@ export default Vue.extend( {
 					return;
 				}
 				if ( selectedProperty.datatype === 'wikibase-item' ) {
-					this.subclassCheckboxVisible = true;
 					this.$store.dispatch( 'setSubclasses', { conditionIndex: this.conditionIndex, subclasses: true } );
 				} else {
-					this.subclassCheckboxVisible = false;
 					this.$store.dispatch( 'setSubclasses', { conditionIndex: this.conditionIndex, subclasses: false } );
 				}
 				this.$store.dispatch( 'updateProperty',
 					{ property: selectedProperty, conditionIndex: this.conditionIndex },
 				);
 			},
+		},
+		isSubclassCheckboxVisible(): boolean {
+			return this.$store.getters.datatype( this.conditionIndex ) === 'wikibase-item';
 		},
 		selectedPropertyValueRelation: {
 			get(): PropertyValueRelation {

--- a/tests/unit/components/QueryCondition.spec.ts
+++ b/tests/unit/components/QueryCondition.spec.ts
@@ -193,6 +193,9 @@ describe( 'QueryCondition.vue', () => {
 			propertyValueRelation: jest.fn().mockReturnValue(
 				jest.fn().mockReturnValue( PropertyValueRelation.Regardless ),
 			),
+			datatype: jest.fn().mockReturnValue(
+				jest.fn().mockReturnValue( 'wikibase-item' ),
+			),
 		} );
 		store.dispatch = jest.fn();
 		const wrapper = shallowMount( QueryCondition, {
@@ -201,9 +204,6 @@ describe( 'QueryCondition.vue', () => {
 			propsData: {
 				'condition-index': 0,
 			},
-		} );
-		wrapper.setData( {
-			subclassCheckboxVisible: true,
 		} );
 		await Vue.nextTick();
 		expect( wrapper.findComponent( SubclassCheckbox ).props( 'disabled' ) ).toBeTruthy();


### PR DESCRIPTION
This resolves the issue that the subclass-checkbox was not shown for properties with datatype `wikibase-item` when reconstructing the Query Builder from a link.

Bug: T274659