### PR TITLE
fix: complete the signature of the i18n plugin

### DIFF
--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -3,7 +3,7 @@ declare module '*.vue' {
 
 	declare module 'vue/types/vue' {
 		interface Vue {
-			$i18n: ( msg: string ) => string;
+			$i18n: ( msg: string, ...args: unknown[] ) => string;
 		}
 	}
 


### PR DESCRIPTION
The i18n allows for providing parameters to the message. These are
usually strings, but could also be numbers, therefore choosing `unknown`
as the type.

Providing the correct signature resolves errors in the IDE that
complained about multiple arguments being provided to a method that only
expected one.