### PR TITLE
chore: better cypress linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,6 @@ module.exports = {
 	},
 	extends: [
 		'plugin:vue/essential',
-		'plugin:cypress/recommended',
-		'plugin:chai-friendly/recommended',
 		'eslint:recommended',
 		'@vue/typescript/recommended',
 		'wikimedia',

--- a/cypress/.eslintrc.js
+++ b/cypress/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+	extends: [
+		'plugin:cypress/recommended',
+		'plugin:chai-friendly/recommended',
+	],
+	parserOptions: {
+		sourceType: 'module',
+	},
+};

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,4 +1,4 @@
-/// <reference types="cypress" />
+// / <reference types="cypress" />
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins
 //
@@ -15,7 +15,7 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-}
+module.exports = ( _on, _config ) => {
+	// `on` is used to hook into various events Cypress emits
+// `config` is the resolved Cypress config
+};

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "cypress": "CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run",
-    "test:lint-cypress": "vue-cli-service lint --no-fix --max-warnings 0 cypress/integration/**",
+    "test:lint-cypress": "vue-cli-service lint --no-fix --max-warnings 0 cypress",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
     "test:unit": "vue-cli-service test:unit",
@@ -19,6 +19,7 @@
     "test:a11y": "jest --testMatch=\"**/tests/a11y/**\"",
     "fix:css": "stylelint '**/*.vue' --fix",
     "fix:ts": "vue-cli-service lint",
+    "fix:cypress": "vue-cli-service lint cypress",
     "netlify": "npx netlify deploy --dir=dist --json"
   },
   "main": "index.js",


### PR DESCRIPTION
This keeps the linting config for cypress confined to that directory and
also lints the code in the entire cypress directory.

It also adds a fix command.