### PR TITLE
Install npm on dev mode instead of production mode

### DIFF
--- a/build/updater.sh
+++ b/build/updater.sh
@@ -2,9 +2,9 @@
 cd /data/project/query-builder-test/query-builder
 git reset --hard origin/master
 git pull
-export NODE_ENV=production
 npm install npm@6.14.8
 ./node_modules/.bin/npm install
+export NODE_ENV=production
 ./node_modules/.bin/npm run build
 rm -rf public_html/*
 cp -R dist/* ../public_html/


### PR DESCRIPTION
This avoids errors like sh: 1: vue-cli-service: not found in build