### PR TITLE
ci: run cypress as part of npm test for migration to Jenkins

### DIFF
--- a/.github/workflows/test-and-netlify.yml
+++ b/.github/workflows/test-and-netlify.yml
@@ -31,11 +31,3 @@ jobs:
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       run: echo "DEPLOY_URL=$(npm run --silent netlify | jq '.deploy_url' --raw-output)" >> $GITHUB_ENV
       id: "deploy"
-    - name: Cypress End-to-end tests
-      uses: cypress-io/github-action@v2
-      with:
-        browser: chrome
-        headless: true
-        config: pageLoadTimeout=60000,baseUrl=${{ env.DEPLOY_URL }}
-      env:
-        CYPRESS_API_URL: 'https://www.wikidata.org/w/api.php'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4283,6 +4283,35 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sideway/address": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
+          "dev": true
+        }
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -6474,6 +6503,15 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
       "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -11691,6 +11729,21 @@
       "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==",
       "dev": true
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "eventemitter2": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
@@ -12688,6 +12741,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "from2": {
@@ -15564,6 +15623,36 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
     },
+    "joi": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
+      }
+    },
     "js-beautify": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.13.5.tgz",
@@ -16623,6 +16712,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "map-visit": {
@@ -19752,6 +19847,15 @@
         }
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -20791,6 +20895,15 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -22544,6 +22657,15 @@
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
       "dev": true
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -22636,6 +22758,136 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
       "dev": true
+    },
+    "start-server-and-test": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.12.0.tgz",
+      "integrity": "sha512-y3M/PLUPkPBsgKoengMIMQeceT8uOnOc4bkdor/RSCK9Ih/j8z4WthSCrAboXLjgtJJWOporAiEQsnYox+THXg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.7.2",
+        "check-more-types": "2.24.0",
+        "debug": "4.3.1",
+        "execa": "3.4.0",
+        "lazy-ass": "1.6.0",
+        "ps-tree": "1.2.0",
+        "wait-on": "5.2.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -22753,6 +23005,15 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
       }
     },
     "stream-each": {
@@ -25174,6 +25435,19 @@
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.1.tgz",
+      "integrity": "sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "joi": "^17.3.0",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5",
+        "rxjs": "^6.6.3"
       }
     },
     "wait-port": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "The Wikidata team"
   },
   "scripts": {
-    "cypress": "CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run",
+    "cypress": "CYPRESS_API_URL=${VUE_APP_WIKIBASE_API_URL} CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
     "test:lint-cypress": "vue-cli-service lint --no-fix --max-warnings 0 cypress",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
@@ -17,6 +17,7 @@
     "test": "npm-run-all test:* && vue-cli-service build",
     "test:lintcss": "stylelint '**/*.vue'",
     "test:a11y": "jest --testMatch=\"**/tests/a11y/**\"",
+    "test:cy": "start-server-and-test serve http-get://localhost:8080 cypress",
     "fix:css": "stylelint '**/*.vue' --fix",
     "fix:ts": "vue-cli-service lint",
     "fix:cypress": "vue-cli-service lint cypress",
@@ -64,6 +65,7 @@
     "postcss-logical": "^4.0.2",
     "sass": "^1.32.7",
     "sass-loader": "^8.0.2",
+    "start-server-and-test": "^1.12.0",
     "stylelint": "^13.10.0",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-use-logical": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "The Wikidata team"
   },
   "scripts": {
-    "cypress": "CYPRESS_API_URL=${VUE_APP_WIKIBASE_API_URL} CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
+    "cypress": "CYPRESS_API_URL='https://www.wikidata.org/w/api.php' CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
     "test:lint-cypress": "vue-cli-service lint --no-fix --max-warnings 0 cypress",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "The Wikidata team"
   },
   "scripts": {
-    "cypress": "CYPRESS_API_URL='https://www.wikidata.org/w/api.php' CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
+    "cypress": "CYPRESS_API_URL=${VUE_APP_WIKIBASE_API_URL} CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
     "test:lint-cypress": "vue-cli-service lint --no-fix --max-warnings 0 cypress",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
@@ -17,7 +17,7 @@
     "test": "npm-run-all test:* && vue-cli-service build",
     "test:lintcss": "stylelint '**/*.vue'",
     "test:a11y": "jest --testMatch=\"**/tests/a11y/**\"",
-    "test:cy": "start-server-and-test serve http-get://localhost:8080 cypress",
+    "test:cy": "env $(grep -v '^#' .env.example | xargs) start-server-and-test serve http-get://localhost:8080 cypress",
     "fix:css": "stylelint '**/*.vue' --fix",
     "fix:ts": "vue-cli-service lint",
     "fix:cypress": "vue-cli-service lint cypress",


### PR DESCRIPTION
With this we should no longer need branch hosting to run the browser tests. The Cypress tests will now run as part of `npm test`. This should hopefully allow us to run all the essential testing in the standard Jenkins Node docker container / job that comes with Browsers preinstalled.

Bug: [T277060](https://phabricator.wikimedia.org/T277060)