### PR TITLE
accessibility improvement: trash can should be focussed last

### DIFF
--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -1,9 +1,5 @@
 <template>
 	<div class="query-condition">
-		<DeleteConditionButton
-			class="query-condition__remove"
-			@click="removeCondition"
-		/>
 		<NegationToggle
 			class="query-condition__toggle-button-group"
 			v-model="negateValue"
@@ -44,6 +40,10 @@
 				/>
 			</div>
 		</div>
+		<DeleteConditionButton
+			class="query-condition__remove"
+			@click="removeCondition"
+		/>
 	</div>
 </template>
 
@@ -188,6 +188,7 @@ export default Vue.extend( {
 $tinyViewportWidth: 38em; // Set so that inputs show all below each other in the smallest layout
 
 .query-condition {
+	display: flex;
 	padding-block: $dimension-layout-xsmall;
 	padding-inline: $dimension-layout-xsmall;
 	border: $border-width-thin $border-style-base $border-color-base-subtle;
@@ -202,6 +203,7 @@ $tinyViewportWidth: 38em; // Set so that inputs show all below each other in the
 	&__remove {
 		margin-inline-start: $dimension-layout-small;
 		float: inline-end;
+		height: max-content;
 	}
 
 	&__toggle-button-group {
@@ -218,6 +220,7 @@ $tinyViewportWidth: 38em; // Set so that inputs show all below each other in the
 
 	&__input-container {
 		display: grid;
+		width: 100%;
 		// 16em == 256px minimum-width as defined by UX
 		grid-template-columns: repeat(auto-fit, minmax(16em, 1fr));
 		grid-gap: $dimension-layout-xsmall;

--- a/src/components/QueryCondition.vue
+++ b/src/components/QueryCondition.vue
@@ -196,6 +196,7 @@ $tinyViewportWidth: 38em; // Set so that inputs show all below each other in the
 	background-color: $background-color-base-default;
 
 	@media (max-width: $tinyViewportWidth) {
+		display: grid;
 		padding-block: $dimension-layout-xxsmall;
 		padding-inline: $dimension-layout-xxsmall;
 	}
@@ -204,6 +205,11 @@ $tinyViewportWidth: 38em; // Set so that inputs show all below each other in the
 		margin-inline-start: $dimension-layout-small;
 		float: inline-end;
 		height: max-content;
+
+		@media (max-width: $tinyViewportWidth) {
+			position: absolute;
+			inset-inline-end: $dimension-layout-xsmall * 2;
+		}
 	}
 
 	&__toggle-button-group {
@@ -220,7 +226,7 @@ $tinyViewportWidth: 38em; // Set so that inputs show all below each other in the
 
 	&__input-container {
 		display: grid;
-		width: 100%;
+		flex: 1;
 		// 16em == 256px minimum-width as defined by UX
 		grid-template-columns: repeat(auto-fit, minmax(16em, 1fr));
 		grid-gap: $dimension-layout-xsmall;


### PR DESCRIPTION
Bug: [T276942](https://phabricator.wikimedia.org/T276942)

I thought about potential ways to tackle this problem.

1. Typescript manipulation.
      We can add some typescript code to change the behavior of Tab navigation. but this is messy and often leads to bugs in       different browsers. 
2.  We can Explicit add a positive  `Tabindex` values to the `NegationToggle` and `DeleteConditionButton` components. but this is not a good pattern. as can be read [here](https://bitsofco.de/how-and-when-to-use-the-tabindex-attribute/)

> There is almost no reason to ever use a positive value to tabindex, and it is actually considered an anti-pattern. If you’re finding the need to use this value to change the order in which elements become focusable, it is likely that what you actually need to do is change the source order of the HTML elements.

3. change the DOM order and make a few tweaks to the style and then let the natural keyboard navigation do its thing.




**I decided to go with number 3**