### PR TITLE
test: only wikibase-item can have subclasses

### DIFF
--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -314,8 +314,8 @@ describe( 'QueryObjectBuilder', () => {
 								},
 								] },
 							object: {
-								termType: 'Literal',
-								value: 'XXXX',
+								termType: 'NamedNode',
+								value: 'http://www.wikidata.org/entity/Q456',
 							},
 						},
 					],
@@ -329,8 +329,8 @@ describe( 'QueryObjectBuilder', () => {
 			conditions: [
 				{
 					propertyId: 'P281',
-					value: 'XXXX',
-					datatype: 'string',
+					value: 'Q456',
+					datatype: 'wikibase-item',
 					propertyValueRelation: PropertyValueRelation.Matching,
 					referenceRelation: ReferenceRelation.Regardless,
 					subclasses: true,

--- a/tests/unit/sparql/buildQuery.spec.ts
+++ b/tests/unit/sparql/buildQuery.spec.ts
@@ -259,13 +259,15 @@ describe( 'buildQuery', () => {
 		expect( actualQuery.replace( /\s+/g, ' ' ) ).toEqual( expectedQuery.replace( /\s+/g, ' ' ) );
 	} );
 
-	it( 'builds a query from a property and a string value with subclasses', async () => {
+	it( 'builds a query from a property and a wikibase-item value with subclasses', async () => {
 		const propertyId = 'P666';
-		const value = 'blah';
+		const value = 'Q456';
 		const subclassesId = process.env.VUE_APP_SUBCLASS_PROPERTY;
 		const expectedQuery =
-		`SELECT DISTINCT ?item WHERE { ?item (p:${propertyId}/ps:${propertyId}/(wdt:${subclassesId}*)) "${value}". }`;
+			`SELECT DISTINCT ?item
+			 WHERE { ?item (p:${propertyId}/ps:${propertyId}/(wdt:${subclassesId}*)) wd:${value}. }`;
 		const condition = getSimpleCondition( propertyId, value );
+		condition.datatype = 'wikibase-item';
 		condition.subclasses = true;
 
 		const actualQuery = buildQuery( {


### PR DESCRIPTION
We shouldn't test for properties with datatype string to produce correct sparql with subclasses enabled - it doesn't make sense and makes refactoring harder.