### PR TITLE
test: add matrix test to cover most SPARQL generation

### DIFF
--- a/tests/unit/sparql/__snapshots__/buildQuerySingleConditionMatrix.spec.ts.snap
+++ b/tests/unit/sparql/__snapshots__/buildQuerySingleConditionMatrix.spec.ts.snap
@@ -1,0 +1,418 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) \\"a string value\\". }"`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) \\"a string value\\".
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "without", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) \\"a string value\\".
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) _:anyValueP123. }"`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) _:anyValueP123.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "without", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) _:anyValueP123.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item (p:P123/ps:P123) ?instance.
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) ?instance.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "without", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) ?instance.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "without", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "without", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "without", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) wd:Q123. }"`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123/(wdt:P279*)) wd:Q123. }"`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) wd:Q123.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) wd:Q123.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "without", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) wd:Q123.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "without", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) wd:Q123.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) _:anyValueP123. }"`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123/(wdt:P279*)) _:anyValueP123. }"`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) _:anyValueP123.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) _:anyValueP123.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "without", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) _:anyValueP123.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "without", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) _:anyValueP123.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item (p:P123/ps:P123) ?instance.
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item (p:P123/ps:P123/(wdt:P279*)) ?instance.
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) ?instance.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "with", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) ?instance.
+    FILTER(EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "without", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) ?instance.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "without", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) ?instance.
+    FILTER(NOT EXISTS { ?statement0 prov:wasDerivedFrom ?reference. })
+  }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123/(wdt:P279*)) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123/(wdt:P279*)) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "without", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "without", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123/(wdt:P279*)) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123/(wdt:P279*)) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123/(wdt:P279*)) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "without", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "without", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123/(wdt:P279*)) _:anyValueP123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?item (p:P123/ps:P123/(wdt:P279*)) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "with", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123/(wdt:P279*)) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "without", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;
+
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "without", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item wikibase:sitelinks _:anyValue.
+  MINUS { ?statement0 (ps:P123/(wdt:P279*)) ?instance. }
+  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+}"
+`;

--- a/tests/unit/sparql/buildQuerySingleConditionMatrix.spec.ts
+++ b/tests/unit/sparql/buildQuerySingleConditionMatrix.spec.ts
@@ -1,0 +1,84 @@
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import ReferenceRelation from '@/data-model/ReferenceRelation';
+import buildQuery from '@/sparql/buildQuery';
+import QueryRepresentation, { Condition } from '@/sparql/QueryRepresentation';
+
+describe( 'buildQuery', () => {
+
+	function splitByNegateOption( condition: Partial<Condition> ): Partial<Condition>[] {
+		return [ true, false ].map( ( option ) => {
+			return {
+				negate: option,
+				...condition,
+			};
+		} );
+	}
+
+	function splitByReferenceOption( condition: Partial<Condition> ): Partial<Condition>[] {
+		return Object.values( ReferenceRelation ).map( ( option ) => {
+			return {
+				referenceRelation: option,
+				...condition,
+			};
+		} );
+	}
+
+	function splitByPropertyValueRelations( condition: Partial<Condition> ): Partial<Condition>[] {
+		return Object.values( PropertyValueRelation ).map( ( option ) => {
+			return {
+				propertyValueRelation: option,
+				...condition,
+			};
+		} );
+	}
+
+	function createConditions( conditionOverrides: Partial<Condition> ): Condition[] {
+		let conditions: Record<string, unknown>[] = [ {
+			propertyId: 'P123',
+			conditionRelation: null,
+			subclasses: false,
+			...conditionOverrides,
+		} ];
+
+		conditions = conditions.map( splitByNegateOption ).flat();
+		conditions = conditions.map( splitByReferenceOption ).flat();
+		conditions = conditions.map( splitByPropertyValueRelations ).flat();
+
+		return conditions as Condition[];
+	}
+
+	function createCases( caseOverrides: Partial<Condition>[] ): Condition[][] {
+		return caseOverrides
+			.map( createConditions )
+			.flat()
+			.map( ( condition: Condition ) => {
+				return [ condition ];
+			} );
+	}
+
+	const caseOverrides: Partial<Condition>[] = [
+		{
+			value: 'a string value',
+			datatype: 'string',
+		},
+		{
+			value: 'Q123',
+			datatype: 'wikibase-item',
+		},
+		{
+			value: 'Q123',
+			datatype: 'wikibase-item',
+			subclasses: true,
+		},
+	];
+
+	it.each(
+		createCases( caseOverrides ),
+	)( 'builds a query from a single condition QueryRepresentation: %p', ( condition: Condition ) => {
+		const simpleQueryCondition: QueryRepresentation = {
+			conditions: [ condition ],
+			omitLabels: true,
+		};
+		expect( buildQuery( simpleQueryCondition ) ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This covers almost every permutation of a single condition QueryRepresentation. It doesn't permutate limit and omitLabels.

These tests are expected to be very useful when refactoring the way we create the SPARQL because they can prove that the SPARQL generation of a condition did not change for any given simple refactoring.

It currently generates _18_ ( 2 negation options * 3 property value options * 3 reference options ) test cases per given set of data. It currently includes 3 sets of data: string value, wikibase-item value, and wikibase-item value with subclasses.

**Reviewing the snapshots now is not necessary!**

Those snapshots are only interesting when they _change_.