### PR TITLE
refactor: make only locally used method private

### DIFF
--- a/src/sparql/TripleBuilder.ts
+++ b/src/sparql/TripleBuilder.ts
@@ -84,7 +84,7 @@ export default class TripleBuilder {
 		};
 	}
 
-	public buildTriplePredicateItems( condition: Condition ): ( PropertyPath|IriTerm )[] {
+	private buildTriplePredicateItems( condition: Condition ): ( PropertyPath | IriTerm )[] {
 		const items: ( PropertyPath|IriTerm )[] = [ {
 			termType: 'NamedNode',
 			value: rdfNamespaces.p + condition.propertyId,


### PR DESCRIPTION
This isn't used outside the TripleBuilder class.