### PR TITLE
fix: env variable values must not contain spaces

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,4 @@ PORT=8080
 VUE_APP_WIKIBASE_API_URL='https://www.wikidata.org/w/api.php'
 VUE_APP_QUERY_SERVICE_EMBED_URL='https://query.wikidata.org/embed.html'
 VUE_APP_QUERY_SERVICE_URL='https://query.wikidata.org/'
-VUE_APP_SUBCLASS_PROPERTY_MAP='{"default": "P279", "P171": "P171", "P131":"P131"}'
+VUE_APP_SUBCLASS_PROPERTY_MAP='{"default":"P279","P171":"P171","P131":"P131"}'


### PR DESCRIPTION
Single quotes are not sufficient quoting to make the shell not interpret those spaces. That has no consequences for the actual usage during building the app, but it breaks when read on the command line in CI.