### PR TITLE
refactor: split base triple regardless of references

### DIFF
--- a/cypress/integration/component-interaction.spec.js
+++ b/cypress/integration/component-interaction.spec.js
@@ -129,11 +129,19 @@ describe( 'Component interaction test', () => {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]". }
   {
     SELECT DISTINCT ?item WHERE {
-      { MINUS { ?item (p:P31/ps:P31/(wdt:P279*)) ?instance. } }
+      {
+        MINUS {
+          ?item p:P31 ?statement0.
+          ?statement0 (ps:P31/(wdt:P279*)) ?instance.
+        }
+      }
       UNION
       { MINUS { ?item (p:P31/ps:P31) wd:Q146. } }
       UNION
-      { ?item (p:P2109/ps:P2109) _:anyValueP2109. }
+      {
+        ?item p:P2109 ?statement1.
+        ?statement1 (ps:P2109) _:anyValueP2109.
+      }
     }
     LIMIT 100
   }

--- a/cypress/integration/error-handling.spec.js
+++ b/cypress/integration/error-handling.spec.js
@@ -80,7 +80,10 @@ describe( 'Test error handling of the Query Building', () => {
 			const expected = `SELECT DISTINCT ?item ?itemLabel WHERE {
   SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE]". }
   {
-    SELECT DISTINCT ?item WHERE { ?item (p:P1429/ps:P1429/(wdt:P279*)) wd:Q146. }
+    SELECT DISTINCT ?item WHERE {
+      ?item p:P1429 ?statement0.
+      ?statement0 (ps:P1429/(wdt:P279*)) wd:Q146.
+    }
     LIMIT 100
   }
 }`;

--- a/src/sparql/PatternBuilder.ts
+++ b/src/sparql/PatternBuilder.ts
@@ -39,16 +39,35 @@ export default class PatternBuilder {
 				conditionIndex,
 			);
 		} else {
+			const statementSubjectName = 'statement' + conditionIndex;
+			const entityToStatementTriple: Triple = {
+				subject: {
+					termType: 'Variable',
+					value: 'item',
+				},
+				predicate: {
+					termType: 'NamedNode',
+					value: rdfNamespaces.p + propertyId,
+				},
+				object: {
+					termType: 'Variable',
+					value: statementSubjectName,
+				},
+			};
+			const statementToValueTriple = this.tripleBuilder.buildTripleFromQueryCondition(
+				propertyId,
+				datatype,
+				propertyValueRelation,
+				value,
+				subclasses,
+				statementSubjectName,
+			);
 			pattern = {
 				type: 'bgp',
-				triples: [ this.tripleBuilder.buildTripleFromQueryCondition(
-					propertyId,
-					datatype,
-					propertyValueRelation,
-					value,
-					subclasses,
-					referenceRelation,
-				) ],
+				triples: [
+					entityToStatementTriple,
+					statementToValueTriple,
+				],
 			};
 		}
 
@@ -128,7 +147,6 @@ export default class PatternBuilder {
 				propertyValueRelation,
 				value,
 				subclasses,
-				referenceRelation,
 				statementSubjectName,
 			) ],
 		};

--- a/src/sparql/TripleBuilder.ts
+++ b/src/sparql/TripleBuilder.ts
@@ -1,7 +1,6 @@
 import { IriTerm, PropertyPath, Term, Triple } from 'sparqljs';
 import PropertyValueRelation from '@/data-model/PropertyValueRelation';
 import rdfNamespaces from '@/sparql/rdfNamespaces';
-import ReferenceRelation from '@/data-model/ReferenceRelation';
 import UnitValue from '@/data-model/UnitValue';
 
 export default class TripleBuilder {
@@ -11,8 +10,7 @@ export default class TripleBuilder {
 		propertyValueRelation: PropertyValueRelation,
 		value: string | UnitValue,
 		subclasses: boolean,
-		referenceRelation: ReferenceRelation,
-		statementSubjectName = 'item',
+		statementSubjectName: string,
 	): Triple {
 		return {
 			subject: {
@@ -22,7 +20,7 @@ export default class TripleBuilder {
 			predicate: {
 				type: 'path',
 				pathType: '/',
-				items: this.buildPredicateItems( propertyId, referenceRelation, subclasses ),
+				items: this.buildPredicateItems( propertyId, subclasses ),
 			},
 			object: this.buildObjectItems( propertyId, datatype, propertyValueRelation, value ),
 		};
@@ -103,23 +101,14 @@ export default class TripleBuilder {
 
 	private buildPredicateItems(
 		propertyId: string,
-		referenceRelation: ReferenceRelation,
 		subclasses: boolean,
 	): ( PropertyPath | IriTerm )[] {
 		const items: ( PropertyPath | IriTerm )[] = [
 			{
 				termType: 'NamedNode',
-				value: rdfNamespaces.p + propertyId,
-			},
-			{
-				termType: 'NamedNode',
 				value: rdfNamespaces.ps + propertyId,
 			},
 		];
-
-		if ( referenceRelation !== ReferenceRelation.Regardless ) {
-			items.shift(); // for references we only need rdfNamespaces.ps
-		}
 
 		if ( subclasses ) {
 			items.push(

--- a/tests/unit/sparql/QueryObjectBuilder.spec.ts
+++ b/tests/unit/sparql/QueryObjectBuilder.spec.ts
@@ -25,17 +25,30 @@ describe( 'QueryObjectBuilder', () => {
 								termType: 'Variable',
 								value: 'item',
 							},
-							predicate: { type: 'path',
+							predicate: {
+								termType: 'NamedNode',
+								value: 'http://www.wikidata.org/prop/P281',
+							},
+							object: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+						},
+						{
+							subject: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+							predicate: {
+								type: 'path',
 								pathType: '/',
-								items: [ {
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/P281',
-								},
-								{
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/statement/P281',
-								},
-								] },
+								items: [
+									{
+										termType: 'NamedNode',
+										value: 'http://www.wikidata.org/prop/statement/P281',
+									},
+								],
+							},
 							object: {
 								termType: 'Literal',
 								value: 'XXXX',
@@ -114,17 +127,30 @@ describe( 'QueryObjectBuilder', () => {
 								termType: 'Variable',
 								value: 'item',
 							},
-							predicate: { type: 'path',
+							predicate: {
+								termType: 'NamedNode',
+								value: 'http://www.wikidata.org/prop/P281',
+							},
+							object: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+						},
+						{
+							subject: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+							predicate: {
+								type: 'path',
 								pathType: '/',
-								items: [ {
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/P281',
-								},
-								{
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/statement/P281',
-								},
-								] },
+								items: [
+									{
+										termType: 'NamedNode',
+										value: 'http://www.wikidata.org/prop/statement/P281',
+									},
+								],
+							},
 							object: {
 								termType: 'Literal',
 								value: 'XXXX',
@@ -179,17 +205,30 @@ describe( 'QueryObjectBuilder', () => {
 								termType: 'Variable',
 								value: 'item',
 							},
-							predicate: { type: 'path',
+							predicate: {
+								termType: 'NamedNode',
+								value: 'http://www.wikidata.org/prop/P281',
+							},
+							object: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+						},
+						{
+							subject: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+							predicate: {
+								type: 'path',
 								pathType: '/',
-								items: [ {
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/P281',
-								},
-								{
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/statement/P281',
-								},
-								] },
+								items: [
+									{
+										termType: 'NamedNode',
+										value: 'http://www.wikidata.org/prop/statement/P281',
+									},
+								],
+							},
 							object: {
 								termType: 'Literal',
 								value: 'XXXX',
@@ -293,26 +332,38 @@ describe( 'QueryObjectBuilder', () => {
 								termType: 'Variable',
 								value: 'item',
 							},
-							predicate: { type: 'path',
+							predicate: {
+								termType: 'NamedNode',
+								value: 'http://www.wikidata.org/prop/P281',
+							},
+							object: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+						},
+						{
+							subject: {
+								termType: 'Variable',
+								value: 'statement0',
+							},
+							predicate: {
+								type: 'path',
 								pathType: '/',
-								items: [ {
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/P281',
-								},
-								{
-									termType: 'NamedNode',
-									value: 'http://www.wikidata.org/prop/statement/P281',
-								},
-								{
-									type: 'path',
-									pathType: '*',
-									items: [ {
+								items: [
+									{
 										termType: 'NamedNode',
-										value: 'http://www.wikidata.org/prop/direct/P279',
+										value: 'http://www.wikidata.org/prop/statement/P281',
 									},
-									],
-								},
-								] },
+									{
+										type: 'path',
+										pathType: '*',
+										items: [ {
+											termType: 'NamedNode',
+											value: 'http://www.wikidata.org/prop/direct/P279',
+										} ],
+									},
+								],
+							},
 							object: {
 								termType: 'NamedNode',
 								value: 'http://www.wikidata.org/entity/Q456',
@@ -387,17 +438,30 @@ describe( 'QueryObjectBuilder', () => {
 										termType: 'Variable',
 										value: 'item',
 									},
-									predicate: { type: 'path',
+									predicate: {
+										termType: 'NamedNode',
+										value: 'http://www.wikidata.org/prop/P281',
+									},
+									object: {
+										termType: 'Variable',
+										value: 'statement0',
+									},
+								},
+								{
+									subject: {
+										termType: 'Variable',
+										value: 'statement0',
+									},
+									predicate: {
+										type: 'path',
 										pathType: '/',
-										items: [ {
-											termType: 'NamedNode',
-											value: 'http://www.wikidata.org/prop/P281',
-										},
-										{
-											termType: 'NamedNode',
-											value: 'http://www.wikidata.org/prop/statement/P281',
-										},
-										] },
+										items: [
+											{
+												termType: 'NamedNode',
+												value: 'http://www.wikidata.org/prop/statement/P281',
+											},
+										],
+									},
 									object: {
 										termType: 'Literal',
 										value: 'XXXX',
@@ -474,17 +538,31 @@ describe( 'QueryObjectBuilder', () => {
 										termType: 'Variable',
 										value: 'item',
 									},
-									predicate: { type: 'path',
+									predicate: {
+										termType: 'NamedNode',
+										value: 'http://www.wikidata.org/prop/P281',
+									},
+									object: {
+										termType: 'Variable',
+										value: 'statement0',
+									},
+								},
+								{
+									subject: {
+										termType: 'Variable',
+										value: 'statement0',
+									},
+									predicate: {
+										type: 'path',
 										pathType: '/',
-										items: [ {
-											termType: 'NamedNode',
-											value: 'http://www.wikidata.org/prop/P281',
-										},
-										{
-											termType: 'NamedNode',
-											value: 'http://www.wikidata.org/prop/statement/P281',
-										},
-										] },
+										items: [
+
+											{
+												termType: 'NamedNode',
+												value: 'http://www.wikidata.org/prop/statement/P281',
+											},
+										],
+									},
 									object: {
 										termType: 'Literal',
 										value: 'XXXX',

--- a/tests/unit/sparql/__snapshots__/buildQuerySingleConditionMatrix.spec.ts.snap
+++ b/tests/unit/sparql/__snapshots__/buildQuerySingleConditionMatrix.spec.ts.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) \\"a string value\\". }"`;
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123) \\"a string value\\".
+}"
+`;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
@@ -22,7 +27,12 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 }"
 `;
 
-exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) _:anyValueP123. }"`;
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123) _:anyValueP123.
+}"
+`;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": false, "value": "a string value"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
@@ -46,7 +56,8 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
-  ?item (p:P123/ps:P123) ?instance.
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123) ?instance.
   MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
 }"
 `;
@@ -76,7 +87,10 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) \\"a string value\\".
+  }
 }"
 `;
 
@@ -109,7 +123,10 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123) _:anyValueP123. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) _:anyValueP123.
+  }
 }"
 `;
 
@@ -142,7 +159,10 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "string", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "a string value"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123) ?instance. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) ?instance.
+  }
   MINUS { ?item (p:P123/ps:P123) \\"a string value\\". }
 }"
 `;
@@ -175,9 +195,19 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 }"
 `;
 
-exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) wd:Q123. }"`;
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123) wd:Q123.
+}"
+`;
 
-exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123/(wdt:P279*)) wd:Q123. }"`;
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123/(wdt:P279*)) wd:Q123.
+}"
+`;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
@@ -219,9 +249,19 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 }"
 `;
 
-exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123) _:anyValueP123. }"`;
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123) _:anyValueP123.
+}"
+`;
 
-exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `"SELECT DISTINCT ?item WHERE { ?item (p:P123/ps:P123/(wdt:P279*)) _:anyValueP123. }"`;
+exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
+"SELECT DISTINCT ?item WHERE {
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123/(wdt:P279*)) _:anyValueP123.
+}"
+`;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "with", "subclasses": false, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
@@ -265,14 +305,16 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
-  ?item (p:P123/ps:P123) ?instance.
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123) ?instance.
   MINUS { ?item (p:P123/ps:P123) wd:Q123. }
 }"
 `;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": false, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
-  ?item (p:P123/ps:P123/(wdt:P279*)) ?instance.
+  ?item p:P123 ?statement0.
+  ?statement0 (ps:P123/(wdt:P279*)) ?instance.
   MINUS { ?item (p:P123/ps:P123) wd:Q123. }
 }"
 `;
@@ -324,14 +366,20 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123) wd:Q123. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) wd:Q123.
+  }
 }"
 `;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "matching", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123/(wdt:P279*)) wd:Q123. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) wd:Q123.
+  }
 }"
 `;
 
@@ -390,14 +438,20 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123) _:anyValueP123. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) _:anyValueP123.
+  }
 }"
 `;
 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "regardless-of-value", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123/(wdt:P279*)) _:anyValueP123. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) _:anyValueP123.
+  }
 }"
 `;
 
@@ -456,7 +510,10 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": false, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123) ?instance. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123) ?instance.
+  }
   MINUS { ?item (p:P123/ps:P123) wd:Q123. }
 }"
 `;
@@ -464,7 +521,10 @@ exports[`buildQuery builds a query from a single condition QueryRepresentation: 
 exports[`buildQuery builds a query from a single condition QueryRepresentation: {"conditionRelation": null, "datatype": "wikibase-item", "negate": true, "propertyId": "P123", "propertyValueRelation": "without", "referenceRelation": "regardless", "subclasses": true, "value": "Q123"} 1`] = `
 "SELECT DISTINCT ?item WHERE {
   ?item wikibase:sitelinks _:anyValue.
-  MINUS { ?item (p:P123/ps:P123/(wdt:P279*)) ?instance. }
+  MINUS {
+    ?item p:P123 ?statement0.
+    ?statement0 (ps:P123/(wdt:P279*)) ?instance.
+  }
   MINUS { ?item (p:P123/ps:P123) wd:Q123. }
 }"
 `;


### PR DESCRIPTION
This changes how the SPARQL that we generate looks (a bit uglier), but has no functional changes.
But it makes future refactoring and especially reference handling much, _much_ easier.
That will be introduced in the next commit, to keep this commit with the changes to the generated SPARQL as small as possible.