### PR TITLE
fix: don't restart condition index in unions

### DIFF
--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -33,14 +33,13 @@ export default class QueryObjectBuilder {
 
 		const conditions = this.buildConditionTree( queryRepresentation.conditions );
 
-		for ( let i = 0; i < conditions.length; i++ ) {
-			const conditionOrUnion = conditions[ i ];
-			if ( Array.isArray( conditionOrUnion ) ) {
-				this.buildUnion( conditionOrUnion );
-				continue;
+		conditions.forEach( ( condition ) => {
+			if ( Array.isArray( condition ) ) {
+				this.buildUnion( condition );
+				return;
 			}
-			this.buildFromQueryCondition( conditionOrUnion, this.conditionIndex++ );
-		}
+			this.buildFromQueryCondition( condition );
+		} );
 
 		if ( this.queryObject.where ) {
 			// If it's a negate query only, we need to add "any item" to it otherwise it returns empty result.
@@ -110,7 +109,7 @@ export default class QueryObjectBuilder {
 		const unionConditions = [];
 		for ( let i = 0; i < conditions.length; i++ ) {
 			unionConditions.push(
-				...this.patternBuilder.buildValuePatternFromCondition( conditions[ i ], this.conditionIndex++ )
+				...this.patternBuilder.buildValuePatternFromCondition( conditions[ i ], this.conditionIndex++ ),
 			);
 		}
 		const union: Pattern = {
@@ -123,12 +122,12 @@ export default class QueryObjectBuilder {
 		this.queryObject.where.push( union );
 	}
 
-	private buildFromQueryCondition( condition: Condition, conditionIndex: number ): void {
+	private buildFromQueryCondition( condition: Condition ): void {
 		if ( !this.queryObject.where ) {
 			this.queryObject.where = [];
 		}
 		this.queryObject.where.push(
-			...this.patternBuilder.buildValuePatternFromCondition( condition, conditionIndex ),
+			...this.patternBuilder.buildValuePatternFromCondition( condition, this.conditionIndex++ ),
 		);
 		return;
 	}

--- a/src/sparql/QueryObjectBuilder.ts
+++ b/src/sparql/QueryObjectBuilder.ts
@@ -8,6 +8,7 @@ type RootNode = ( Condition | Condition[] )[];
 export default class QueryObjectBuilder {
 	private queryObject: SelectQuery;
 	private patternBuilder: PatternBuilder;
+	private conditionIndex = 0;
 
 	public constructor() {
 		this.queryObject = {
@@ -38,7 +39,7 @@ export default class QueryObjectBuilder {
 				this.buildUnion( conditionOrUnion );
 				continue;
 			}
-			this.buildFromQueryCondition( conditionOrUnion, i );
+			this.buildFromQueryCondition( conditionOrUnion, this.conditionIndex++ );
 		}
 
 		if ( this.queryObject.where ) {
@@ -108,7 +109,9 @@ export default class QueryObjectBuilder {
 	private buildUnion( conditions: Condition[] ): void {
 		const unionConditions = [];
 		for ( let i = 0; i < conditions.length; i++ ) {
-			unionConditions.push( ...this.patternBuilder.buildValuePatternFromCondition( conditions[ i ], i ) );
+			unionConditions.push(
+				...this.patternBuilder.buildValuePatternFromCondition( conditions[ i ], this.conditionIndex++ )
+			);
 		}
 		const union: Pattern = {
 			type: 'union',


### PR DESCRIPTION
This fixes a bug that would reuse a condition index in the for-loop of a union.

It would occur when both condition outside the union and inside the union care about references. A failing test is implicitly added by changing the existing tests in #235