### PR TITLE
refactor: extract separate Pattern builders for string and items

### DIFF
--- a/src/sparql/ItemValueBuilder.ts
+++ b/src/sparql/ItemValueBuilder.ts
@@ -1,0 +1,160 @@
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { Condition } from '@/sparql/QueryRepresentation';
+import rdfNamespaces from '@/sparql/rdfNamespaces';
+import SyntaxBuilder from '@/sparql/SyntaxBuilder';
+import TripleBuilder from '@/sparql/TripleBuilder';
+import ValuePatternBuilder from '@/sparql/ValuePatternBuilder';
+import { MinusPattern, Pattern, PropertyPath, Term } from 'sparqljs';
+
+export default class ItemValueBuilder implements ValuePatternBuilder {
+	private readonly tripleBuilder: TripleBuilder;
+	private readonly syntaxBuilder: SyntaxBuilder;
+
+	public constructor() {
+		this.tripleBuilder = new TripleBuilder();
+		this.syntaxBuilder = new SyntaxBuilder();
+	}
+
+	public buildValuePatternFromCondition( condition: Condition, conditionIndex: number ): Pattern[] {
+		const {
+			propertyId,
+			referenceRelation,
+			propertyValueRelation,
+			datatype,
+			value,
+			negate,
+			subclasses,
+		} = condition;
+
+		if ( datatype !== 'wikibase-item' ) {
+			throw new Error( 'Expected datatype wikibase-item, got: ' + datatype );
+		}
+		if ( typeof value !== 'string' ) {
+			throw new Error( 'Unexpected wikibase-item value type: ' + typeof value );
+		}
+		let patterns: Pattern[] = [];
+
+		const statementVariable = this.syntaxBuilder.buildVariableTermFromName( 'statement' + conditionIndex );
+		const entityToStatementTriple = this.syntaxBuilder.buildSimpleTriple(
+			{
+				termType: 'Variable',
+				value: 'item',
+			},
+			rdfNamespaces.p + propertyId,
+			statementVariable,
+		);
+		const statementToValueTriple = this.syntaxBuilder.buildPathTriple(
+			statementVariable,
+			this.buildStatementToValuePredicateItems(
+				propertyId, subclasses,
+			),
+			this.buildObjectItems( propertyId, propertyValueRelation, value ),
+		);
+		const entityValuePattern = this.syntaxBuilder.buildBgpPattern( [
+			entityToStatementTriple,
+			statementToValueTriple,
+		] );
+		patterns.push( entityValuePattern );
+
+		const referenceFilterPattern = this.tripleBuilder.buildReferenceFilterPattern(
+			referenceRelation,
+			statementVariable,
+		);
+		if ( referenceFilterPattern !== null ) {
+			patterns.push( referenceFilterPattern );
+			patterns = [ { type: 'group', patterns } ];
+		}
+
+		if ( negate ) {
+			patterns = [ {
+				type: 'minus',
+				patterns,
+			} ];
+		}
+
+		if ( propertyValueRelation === PropertyValueRelation.NotMatching ) {
+			const notMatchingPattern = this.buildNotMatchingPattern( propertyId, value );
+			patterns.push( notMatchingPattern );
+		}
+
+		return patterns;
+	}
+
+	private buildNotMatchingPattern( propertyId: string, value: string ): MinusPattern {
+		const notMatchingValueTriple = this.syntaxBuilder.buildPathTriple(
+			{
+				termType: 'Variable',
+				value: 'item',
+			},
+			[
+				rdfNamespaces.p + propertyId,
+				rdfNamespaces.ps + propertyId,
+				// todo: should this have the subclass as well?
+			],
+			{
+				termType: 'NamedNode',
+				value: `${rdfNamespaces.wd}${value}`,
+			},
+		);
+		return {
+			type: 'minus',
+			patterns: [ this.syntaxBuilder.buildBgpPattern( [ notMatchingValueTriple ] ) ],
+		};
+	}
+
+	private buildStatementToValuePredicateItems(
+		propertyId: string, subclasses: boolean,
+	): ( PropertyPath | string )[] {
+		const statementToValuePredicateItems: ( PropertyPath | string )[] = [
+			rdfNamespaces.ps + propertyId,
+		];
+		if ( subclasses ) {
+			statementToValuePredicateItems.push(
+				this.syntaxBuilder.buildPropertyPath( '*', [
+					{
+						termType: 'NamedNode',
+						value: rdfNamespaces.wdt + this.getSubclassPropertyId( propertyId ),
+					},
+				] ),
+			);
+		}
+		return statementToValuePredicateItems;
+	}
+
+	private getSubclassPropertyId( propertyId: string ): string {
+		if ( !process.env.VUE_APP_SUBCLASS_PROPERTY_MAP ) {
+			return 'P279';
+		}
+		const propertyMap = JSON.parse( process.env.VUE_APP_SUBCLASS_PROPERTY_MAP );
+		if ( !propertyMap[ propertyId ] ) {
+			return propertyMap.default;
+		}
+		return propertyMap[ propertyId ];
+	}
+
+	private buildObjectItems(
+		propertyId: string,
+		propertyValueRelation: PropertyValueRelation,
+		value: string,
+	): Term {
+		switch ( propertyValueRelation ) {
+			case ( PropertyValueRelation.NotMatching ):
+				return {
+					termType: 'Variable',
+					value: 'instance', // TODO should this have + propertyId?
+				};
+			case ( PropertyValueRelation.Regardless ):
+				return {
+					termType: 'BlankNode',
+					value: 'anyValue' + propertyId,
+				};
+			case ( PropertyValueRelation.Matching ):
+				return {
+					termType: 'NamedNode',
+					value: `${rdfNamespaces.wd}${value}`,
+				};
+			default:
+				throw new Error( `unsupported relation: ${propertyValueRelation}` );
+		}
+	}
+}

--- a/src/sparql/LimitedSupportPatternBuilder.ts
+++ b/src/sparql/LimitedSupportPatternBuilder.ts
@@ -1,0 +1,70 @@
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { Condition } from '@/sparql/QueryRepresentation';
+import rdfNamespaces from '@/sparql/rdfNamespaces';
+import SyntaxBuilder from '@/sparql/SyntaxBuilder';
+import TripleBuilder from '@/sparql/TripleBuilder';
+import ValuePatternBuilder from '@/sparql/ValuePatternBuilder';
+import { Pattern } from 'sparqljs';
+
+export default class LimitedSupportPatternBuilder implements ValuePatternBuilder {
+	private readonly tripleBuilder: TripleBuilder;
+	private readonly syntaxBuilder: SyntaxBuilder;
+
+	public constructor() {
+		this.tripleBuilder = new TripleBuilder();
+		this.syntaxBuilder = new SyntaxBuilder();
+	}
+
+	public buildValuePatternFromCondition( condition: Condition, conditionIndex: number ): Pattern[] {
+		const {
+			propertyId,
+			referenceRelation,
+			propertyValueRelation,
+			negate,
+		} = condition;
+
+		if ( propertyValueRelation !== PropertyValueRelation.Regardless ) {
+			throw new Error( 'datatypes with limited support _must_ have PropertyValueRelation.Regardless!' );
+		}
+
+		let patterns: Pattern[] = [];
+
+		const statementVariable = this.syntaxBuilder.buildVariableTermFromName( 'statement' + conditionIndex );
+		const entityToStatementTriple = this.syntaxBuilder.buildSimpleTriple(
+			{ termType: 'Variable', value: 'item' },
+			rdfNamespaces.p + propertyId,
+			statementVariable,
+		);
+		const statementToValueTriple = this.syntaxBuilder.buildPathTriple(
+			statementVariable,
+			[ rdfNamespaces.ps + propertyId ],
+			{
+				termType: 'BlankNode',
+				value: 'anyValue' + propertyId,
+			},
+		);
+		const entityValuePattern = this.syntaxBuilder.buildBgpPattern( [
+			entityToStatementTriple,
+			statementToValueTriple,
+		] );
+		patterns.push( entityValuePattern );
+
+		const referenceFilterPattern = this.tripleBuilder.buildReferenceFilterPattern(
+			referenceRelation,
+			statementVariable,
+		);
+		if ( referenceFilterPattern !== null ) {
+			patterns.push( referenceFilterPattern );
+			patterns = [ { type: 'group', patterns } ];
+		}
+
+		if ( negate ) {
+			patterns = [ {
+				type: 'minus',
+				patterns,
+			} ];
+		}
+
+		return patterns;
+	}
+}

--- a/src/sparql/PatternBuilder.ts
+++ b/src/sparql/PatternBuilder.ts
@@ -1,12 +1,12 @@
-import UnitValue from '@/data-model/UnitValue';
-import TripleBuilder from '@/sparql/TripleBuilder';
-import rdfNamespaces from '@/sparql/rdfNamespaces';
+import ItemValueBuilder from '@/sparql/ItemValueBuilder';
+import LimitedSupportPatternBuilder from '@/sparql/LimitedSupportPatternBuilder';
 import { Condition } from '@/sparql/QueryRepresentation';
-import { FilterPattern, GroupPattern, Pattern, Triple } from 'sparqljs';
-import ReferenceRelation from '@/data-model/ReferenceRelation';
-import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import StringValuePatternBuilder from '@/sparql/StringValuePatternBuilder';
+import TripleBuilder from '@/sparql/TripleBuilder';
+import ValuePatternBuilder from '@/sparql/ValuePatternBuilder';
+import { Pattern } from 'sparqljs';
 
-export default class PatternBuilder {
+export default class PatternBuilder implements ValuePatternBuilder {
 	private tripleBuilder: TripleBuilder;
 
 	public constructor() {
@@ -14,85 +14,20 @@ export default class PatternBuilder {
 	}
 
 	public buildValuePatternFromCondition( condition: Condition, conditionIndex: number ): Pattern[] {
-		const {
-			propertyId,
-			referenceRelation,
-			propertyValueRelation,
-			datatype,
-			subclasses,
-			value,
-			negate,
-		} = condition;
+		return this.getValuePatternBuilderForDatatype( condition.datatype )
+			.buildValuePatternFromCondition( condition, conditionIndex );
+	}
 
-		const patterns: Pattern[] = [];
-
-		let pattern: Pattern;
-
-		if ( referenceRelation !== ReferenceRelation.Regardless ) {
-			pattern = this.buildReferencesGroupPattern(
-				propertyId,
-				datatype,
-				propertyValueRelation,
-				value,
-				subclasses,
-				referenceRelation,
-				conditionIndex,
-			);
-		} else {
-			const statementSubjectName = 'statement' + conditionIndex;
-			const entityToStatementTriple: Triple = {
-				subject: {
-					termType: 'Variable',
-					value: 'item',
-				},
-				predicate: {
-					termType: 'NamedNode',
-					value: rdfNamespaces.p + propertyId,
-				},
-				object: {
-					termType: 'Variable',
-					value: statementSubjectName,
-				},
-			};
-			const statementToValueTriple = this.tripleBuilder.buildTripleFromQueryCondition(
-				propertyId,
-				datatype,
-				propertyValueRelation,
-				value,
-				subclasses,
-				statementSubjectName,
-			);
-			pattern = {
-				type: 'bgp',
-				triples: [
-					entityToStatementTriple,
-					statementToValueTriple,
-				],
-			};
+	private getValuePatternBuilderForDatatype( datatype: string ): ValuePatternBuilder {
+		switch ( datatype ) {
+			case 'string':
+			case 'external-id':
+				return new StringValuePatternBuilder();
+			case 'wikibase-item':
+				return new ItemValueBuilder();
+			default:
+				return new LimitedSupportPatternBuilder();
 		}
-
-		if ( negate ) {
-			pattern = {
-				type: 'minus',
-				patterns: [ pattern ],
-			};
-		}
-
-		patterns.push( pattern );
-
-		if ( propertyValueRelation === PropertyValueRelation.NotMatching ) {
-			const filterCondition = {
-				type: 'minus',
-				patterns: [ {
-					type: 'bgp',
-					triples: [ this.tripleBuilder.buildTripleForNotMatchingValue( propertyId, datatype, value ) ],
-				} ],
-			};
-
-			patterns.push( filterCondition as Pattern );
-		}
-
-		return patterns;
 	}
 
 	public buildLabelServicePattern(): Pattern {
@@ -106,78 +41,6 @@ export default class PatternBuilder {
 		return {
 			type: 'bgp',
 			triples: [ this.tripleBuilder.buildAnyValueTripe() ],
-		};
-	}
-
-	private buildReferencesGroupPattern(
-		propertyId: string,
-		datatype: string,
-		propertyValueRelation: PropertyValueRelation,
-		value: string | UnitValue,
-		subclasses: boolean,
-		referenceRelation: ReferenceRelation,
-		conditionIndex: number,
-	): GroupPattern {
-		const statementSubjectName = 'statement' + conditionIndex;
-		const referenceTriple: Triple = {
-			subject: {
-				termType: 'Variable',
-				value: 'item',
-			},
-			predicate: {
-				termType: 'NamedNode',
-				value: rdfNamespaces.p + propertyId,
-			},
-			object: {
-				termType: 'Variable',
-				value: statementSubjectName,
-			},
-		};
-
-		const bgpReference: Pattern = {
-			type: 'bgp',
-			triples: [ referenceTriple ],
-		};
-
-		const bgp: Pattern = {
-			type: 'bgp',
-			triples: [ this.tripleBuilder.buildTripleFromQueryCondition(
-				propertyId,
-				datatype,
-				propertyValueRelation,
-				value,
-				subclasses,
-				statementSubjectName,
-			) ],
-		};
-
-		let referenceExistsOrNot = '';
-
-		if ( referenceRelation === ReferenceRelation.With ) {
-			referenceExistsOrNot = 'exists';
-		} else if ( referenceRelation === ReferenceRelation.Without ) {
-			referenceExistsOrNot = 'notexists';
-		}
-
-		const referenceFilter: FilterPattern = {
-			type: 'filter',
-			expression: {
-				type: 'operation',
-				operator: referenceExistsOrNot,
-				args: [
-					{
-						type: 'bgp',
-						triples: [
-							this.tripleBuilder.buildReferenceFilterTriple( statementSubjectName ),
-						],
-					},
-				],
-			},
-		};
-
-		return {
-			type: 'group',
-			patterns: [ bgpReference, bgp, referenceFilter ],
 		};
 	}
 }

--- a/src/sparql/StringValuePatternBuilder.ts
+++ b/src/sparql/StringValuePatternBuilder.ts
@@ -1,0 +1,126 @@
+import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import { Condition } from '@/sparql/QueryRepresentation';
+import rdfNamespaces from '@/sparql/rdfNamespaces';
+import SyntaxBuilder from '@/sparql/SyntaxBuilder';
+import TripleBuilder from '@/sparql/TripleBuilder';
+import ValuePatternBuilder from '@/sparql/ValuePatternBuilder';
+import { MinusPattern, Pattern, Term } from 'sparqljs';
+
+export default class StringValuePatternBuilder implements ValuePatternBuilder {
+	private readonly ALLOWED_DATATYPES = [ 'string', 'external-id' ];
+
+	private readonly tripleBuilder: TripleBuilder;
+	private readonly syntaxBuilder: SyntaxBuilder;
+
+	public constructor() {
+		this.tripleBuilder = new TripleBuilder();
+		this.syntaxBuilder = new SyntaxBuilder();
+	}
+
+	public buildValuePatternFromCondition( condition: Condition, conditionIndex: number ): Pattern[] {
+		const {
+			propertyId,
+			referenceRelation,
+			propertyValueRelation,
+			datatype,
+			value,
+			negate,
+		} = condition;
+
+		if ( !this.ALLOWED_DATATYPES.includes( datatype ) ) {
+			throw new Error( 'Unexpected datatype: ' + datatype );
+		}
+		if ( typeof value !== 'string' ) {
+			throw new Error( 'Unexpected value type: ' + typeof value );
+		}
+		let patterns: Pattern[] = [];
+
+		const statementVariable = this.syntaxBuilder.buildVariableTermFromName( 'statement' + conditionIndex );
+		const entityToStatementTriple = this.syntaxBuilder.buildSimpleTriple(
+			{ termType: 'Variable', value: 'item' },
+			rdfNamespaces.p + propertyId,
+			statementVariable,
+		);
+		const statementToValueTriple = this.syntaxBuilder.buildPathTriple(
+			statementVariable,
+			[ rdfNamespaces.ps + propertyId ],
+			this.buildObjectItems( propertyId, propertyValueRelation, value ),
+		);
+		const entityValuePattern = this.syntaxBuilder.buildBgpPattern( [
+			entityToStatementTriple,
+			statementToValueTriple,
+		] );
+		patterns.push( entityValuePattern );
+
+		const referenceFilterPattern = this.tripleBuilder.buildReferenceFilterPattern(
+			referenceRelation,
+			statementVariable,
+		);
+		if ( referenceFilterPattern !== null ) {
+			patterns.push( referenceFilterPattern );
+			patterns = [ { type: 'group', patterns } ];
+		}
+
+		if ( negate ) {
+			patterns = [ {
+				type: 'minus',
+				patterns,
+			} ];
+		}
+
+		if ( propertyValueRelation === PropertyValueRelation.NotMatching ) {
+			const notMatchingPattern = this.buildNotMatchingPattern( propertyId, value );
+			patterns.push( notMatchingPattern );
+		}
+
+		return patterns;
+	}
+
+	private buildNotMatchingPattern( propertyId: string, value: string ): MinusPattern {
+		const notMatchingValueTriple = this.syntaxBuilder.buildPathTriple(
+			{
+				termType: 'Variable',
+				value: 'item',
+			},
+			[
+				rdfNamespaces.p + propertyId,
+				rdfNamespaces.ps + propertyId,
+			],
+			{
+				termType: 'Literal',
+				value,
+			},
+		);
+		return {
+			type: 'minus',
+			patterns: [ this.syntaxBuilder.buildBgpPattern( [ notMatchingValueTriple ] ) ],
+		};
+	}
+
+	private buildObjectItems(
+		propertyId: string,
+		propertyValueRelation: PropertyValueRelation,
+		value: string,
+	): Term {
+		switch ( propertyValueRelation ) {
+			case ( PropertyValueRelation.NotMatching ):
+				return {
+					termType: 'Variable',
+					value: 'instance', // TODO should this have + propertyId?
+				};
+			case ( PropertyValueRelation.Regardless ):
+				return {
+					termType: 'BlankNode',
+					value: 'anyValue' + propertyId,
+				};
+			case ( PropertyValueRelation.Matching ):
+				return {
+					termType: 'Literal',
+					value,
+				};
+			default:
+				throw new Error( `unsupported relation: ${propertyValueRelation}` );
+		}
+	}
+
+}

--- a/src/sparql/SyntaxBuilder.ts
+++ b/src/sparql/SyntaxBuilder.ts
@@ -1,0 +1,75 @@
+import {
+	BgpPattern,
+	BlankTerm,
+	IriTerm,
+	PropertyPath,
+	QuadTerm,
+	Term,
+	Triple,
+	VariableTerm,
+} from 'sparqljs';
+
+export default class SyntaxBuilder {
+
+	public buildSimpleTriple(
+		subject: IriTerm | BlankTerm | VariableTerm | QuadTerm,
+		predicateValue: string,
+		object: Term,
+	): Triple {
+		return {
+			subject,
+			predicate: {
+				termType: 'NamedNode',
+				value: predicateValue,
+			},
+			object,
+		};
+	}
+
+	public buildPathTriple(
+		subject: IriTerm | BlankTerm | VariableTerm | QuadTerm,
+		pathItems: ( string | PropertyPath )[],
+		object: Term,
+	): Triple {
+		return {
+			subject,
+			predicate: this.buildPropertyPath(
+				'/',
+				pathItems.map( ( predicateItem ): IriTerm | PropertyPath => {
+					if ( typeof predicateItem === 'string' ) {
+						return {
+							termType: 'NamedNode',
+							value: predicateItem,
+						};
+					}
+					return predicateItem;
+				} ) ),
+			object,
+		};
+	}
+
+	public buildPropertyPath(
+		pathType: '|' | '/' | '^' | '+' | '*' | '!',
+		pathItems: ( IriTerm | PropertyPath )[],
+	): PropertyPath {
+		return {
+			type: 'path',
+			pathType,
+			items: pathItems,
+		};
+	}
+
+	public buildVariableTermFromName( name: string ): VariableTerm {
+		return {
+			termType: 'Variable',
+			value: name,
+		};
+	}
+
+	public buildBgpPattern( triples: Triple[] ): BgpPattern {
+		return {
+			type: 'bgp',
+			triples,
+		};
+	}
+}

--- a/src/sparql/TripleBuilder.ts
+++ b/src/sparql/TripleBuilder.ts
@@ -1,159 +1,39 @@
-import { IriTerm, PropertyPath, Term, Triple } from 'sparqljs';
-import PropertyValueRelation from '@/data-model/PropertyValueRelation';
+import ReferenceRelation from '@/data-model/ReferenceRelation';
+import SyntaxBuilder from '@/sparql/SyntaxBuilder';
+import { FilterPattern, Triple, VariableTerm } from 'sparqljs';
 import rdfNamespaces from '@/sparql/rdfNamespaces';
-import UnitValue from '@/data-model/UnitValue';
 
 export default class TripleBuilder {
-	public buildTripleFromQueryCondition(
-		propertyId: string,
-		datatype: string,
-		propertyValueRelation: PropertyValueRelation,
-		value: string | UnitValue,
-		subclasses: boolean,
-		statementSubjectName: string,
-	): Triple {
-		return {
-			subject: {
-				termType: 'Variable',
-				value: statementSubjectName,
-			},
-			predicate: {
-				type: 'path',
-				pathType: '/',
-				items: this.buildPredicateItems( propertyId, subclasses ),
-			},
-			object: this.buildObjectItems( propertyId, datatype, propertyValueRelation, value ),
-		};
+
+	private readonly syntaxBuilder: SyntaxBuilder;
+
+	public constructor() {
+		this.syntaxBuilder = new SyntaxBuilder();
 	}
 
-	private checkValueType( value: string | UnitValue ): string | number {
-		if ( typeof value === 'string' ) {
-			return value;
+	public buildReferenceFilterPattern(
+		referenceRelation: ReferenceRelation,
+		statementVariable: VariableTerm,
+	): FilterPattern | null {
+		if ( referenceRelation === ReferenceRelation.Regardless ) {
+			return null;
 		}
-		throw new Error( 'Unit Values not yet supported!!' );
-	}
-
-	private buildObjectItems(
-		propertyId: string,
-		datatype: string,
-		propertyValueRelation: PropertyValueRelation,
-		value: string | UnitValue,
-	): Term {
-		switch ( propertyValueRelation ) {
-			case ( PropertyValueRelation.NotMatching ):
-				return {
-					termType: 'Variable',
-					value: 'instance',
-				};
-			case ( PropertyValueRelation.Regardless ):
-				return {
-					termType: 'BlankNode',
-					value: 'anyValue' + propertyId,
-				};
-			case ( PropertyValueRelation.Matching ):
-				return this.buildExplicitValueObjectItems( datatype, this.checkValueType( value ) );
-			default:
-				throw new Error( `unsupported relation: ${propertyValueRelation}` );
-		}
-	}
-
-	private buildExplicitValueObjectItems( datatype: string, value: string | number ): Term {
-		switch ( datatype ) {
-			case 'string':
-			case 'external-id':
-				return {
-					termType: 'Literal',
-					value: String( value ),
-				};
-			case 'wikibase-item':
-				return {
-					termType: 'NamedNode', // this.mapDatatypeToTermType( condition.datatype ),
-					value: `${rdfNamespaces.wd}${value}`,
-				};
-			default:
-				throw new Error( `unsupported datatype: ${datatype}` );
-		}
-	}
-
-	public buildTripleForNotMatchingValue( propertyId: string, datatype: string, value: string | UnitValue ): Triple {
-		return {
-			subject: {
-				termType: 'Variable',
-				value: 'item',
-			},
-			predicate: {
-				type: 'path',
-				pathType: '/',
-				items: [
-					{
-						termType: 'NamedNode',
-						value: rdfNamespaces.p + propertyId,
-					},
-					{
-						termType: 'NamedNode',
-						value: rdfNamespaces.ps + propertyId,
-					},
-				],
-			},
-			object: this.buildExplicitValueObjectItems( datatype, this.checkValueType( value ) ),
-		};
-	}
-
-	private buildPredicateItems(
-		propertyId: string,
-		subclasses: boolean,
-	): ( PropertyPath | IriTerm )[] {
-		const items: ( PropertyPath | IriTerm )[] = [
+		const referencePattern = this.syntaxBuilder.buildSimpleTriple(
+			statementVariable,
+			rdfNamespaces.prov + 'wasDerivedFrom',
 			{
-				termType: 'NamedNode',
-				value: rdfNamespaces.ps + propertyId,
-			},
-		];
-
-		if ( subclasses ) {
-			items.push(
-				{
-					type: 'path',
-					pathType: '*',
-					items: [ {
-						termType: 'NamedNode',
-						value: rdfNamespaces.wdt + this.getSubclassPropertyId( propertyId ),
-					},
-					],
-				},
-			);
-		}
-
-		return items;
-	}
-
-	private getSubclassPropertyId( propertyId: string ): string {
-		if ( !process.env.VUE_APP_SUBCLASS_PROPERTY_MAP ) {
-			return 'P279';
-		}
-		const propertyMap = JSON.parse( process.env.VUE_APP_SUBCLASS_PROPERTY_MAP );
-		if ( !propertyMap[ propertyId ] ) {
-			return propertyMap.default;
-		}
-		return propertyMap[ propertyId ];
-
-	}
-
-	public buildReferenceFilterTriple( statementSubjectName: string ): Triple {
-		return {
-			subject: {
-				termType: 'Variable',
-				value: statementSubjectName,
-			},
-			predicate: {
-				termType: 'NamedNode',
-				value: rdfNamespaces.prov + 'wasDerivedFrom',
-			},
-			object: {
 				termType: 'Variable',
 				value: 'reference',
 			},
-		};
+		);
+		return {
+			type: 'filter',
+			expression: {
+				type: 'operation',
+				operator: referenceRelation === ReferenceRelation.With ? 'exists' : 'notexists',
+				args: [ this.syntaxBuilder.buildBgpPattern( [ referencePattern ] ) ],
+			},
+		} as FilterPattern;
 	}
 
 	public buildAnyValueTripe(): Triple {

--- a/src/sparql/ValuePatternBuilder.ts
+++ b/src/sparql/ValuePatternBuilder.ts
@@ -1,0 +1,6 @@
+import { Condition } from '@/sparql/QueryRepresentation';
+import { Pattern } from 'sparqljs';
+
+export default interface ValuePatternBuilder {
+	buildValuePatternFromCondition( condition: Condition, conditionIndex: number ): Pattern[];
+}


### PR DESCRIPTION
This slices and dices the PatternBuilder and TripleBuilder in a new way. There is now a StringPatternValueBuilder for strings and external IDs and a ItemValuePatternBuilder for wikibase-item.

While these two classes share seemingly some logic, most of that is incidental. The generation of the references filter is however independent from the datatype and shared via the TripleBuilder.

The SyntaxBuilder is basically just a thin abstraction layer on top of sparqljs and depends only on it.

This setup allows us to add a QuantityValuePatternBuilder in the next step and a DateValuePatternBuilder in the future.

**Note that the tests do not change.**