### PR TITLE
test: use LilyPond instead of quantity as limited support example

### DIFF
--- a/cypress/fixtures/wbsearchentities-limited-support.json
+++ b/cypress/fixtures/wbsearchentities-limited-support.json
@@ -1,24 +1,24 @@
 {
-    "searchinfo": {
-      "search": "installed capacity"
-    },
-    "search": [
-      {
-        "id": "P2109",
-        "title": "Property:P2109",
-        "pageid": 23065851,
-        "repository": "wikidata",
-        "url": "//www.wikidata.org/wiki/Property:P2109",
-        "datatype": "quantity",
-        "concepturi": "http://www.wikidata.org/entity/P2109",
-        "label": "installed capacity",
-        "description": "power produced by the engine or plant (use with unit of power)",
-        "match": {
-          "type": "label",
-          "language": "en",
-          "text": "installed capacity"
-        }
+  "searchinfo": {
+    "search": "LilyPond notation"
+  },
+  "search": [
+    {
+      "id": "P6883",
+      "title": "Property:P6883",
+      "pageid": 64462541,
+      "repository": "wikidata",
+      "url": "//www.wikidata.org/wiki/Property:P6883",
+      "datatype": "musical-notation",
+      "concepturi": "http://www.wikidata.org/entity/P6883",
+      "label": "LilyPond notation",
+      "description": "musical notation in LilyPond syntax",
+      "match": {
+        "type": "label",
+        "language": "en",
+        "text": "LilyPond notation"
       }
-    ],
-    "success": 1
-  }
+    }
+  ],
+  "success": 1
+}

--- a/cypress/integration/component-interaction.spec.js
+++ b/cypress/integration/component-interaction.spec.js
@@ -36,7 +36,7 @@ describe( 'Component interaction test', () => {
 		).as( 'hasImdbRequest' );
 
 		cy.intercept(
-			wikibaseApiRequest( { action: 'wbsearchentities', search: 'installed capacity' } ),
+			wikibaseApiRequest( { action: 'wbsearchentities', search: 'LilyPond notation' } ),
 			{ fixture: 'wbsearchentities-limited-support.json' },
 		).as( 'hasLimitedSupportedRequest' );
 
@@ -110,7 +110,7 @@ describe( 'Component interaction test', () => {
 
 		cy.get( '.query-condition__property-lookup .wikit-Input' )
 			.eq( 1 )
-			.type( 'installed capacity' )
+			.type( 'LilyPond notation' )
 			.wait( '@hasLimitedSupportedRequest' );
 		cy.get( '.query-condition__property-lookup:nth(1) .wikit-OptionsMenu__item' ).click();
 
@@ -139,8 +139,8 @@ describe( 'Component interaction test', () => {
       { MINUS { ?item (p:P31/ps:P31) wd:Q146. } }
       UNION
       {
-        ?item p:P2109 ?statement1.
-        ?statement1 (ps:P2109) _:anyValueP2109.
+        ?item p:P6883 ?statement1.
+        ?statement1 (ps:P6883) _:anyValueP6883.
       }
     }
     LIMIT 100


### PR DESCRIPTION
Since we are now implementing support for the quantity datatype, we should switch the example for limited support to something that is not going to be supported for a long time: LilyPond musical notation syntax.