### PR TITLE
Unset DISPLAY when running cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "The Wikidata team"
   },
   "scripts": {
-    "cypress": "CYPRESS_API_URL=${VUE_APP_WIKIBASE_API_URL} CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
+    "cypress": "unset DISPLAY && CYPRESS_API_URL=${VUE_APP_WIKIBASE_API_URL} CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://localhost:8080} cypress run --browser chromium --headless",
     "test:lint-cypress": "vue-cli-service lint --no-fix --max-warnings 0 cypress",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",


### PR DESCRIPTION
Currently, cypress is failing to start in jenkins (in gerrit) due to
this.

For more information see https://github.com/cypress-io/cypress/issues/4034

Bug: T277060